### PR TITLE
Update IsEnabled condition in IPCSubscriber

### DIFF
--- a/AutoDuty/IPC/IPCSubscriber.cs
+++ b/AutoDuty/IPC/IPCSubscriber.cs
@@ -15,7 +15,7 @@ namespace AutoDuty.IPC
     {
         private static EzIPCDisposalToken[] _disposalTokens = EzIPC.Init(typeof(BossMod_IPCSubscriber), "BossMod");
 
-        internal static bool IsEnabled => IPCSubscriber_Common.IsReady("BossMod");
+        internal static bool IsEnabled => IPCSubscriber_Common.IsReady("BossMod") || IPCSubscriber_Common.IsReady("BossModReborn");
 
         [EzIPC] internal static readonly Func<bool> IsMoving;
         [EzIPC] internal static readonly Func<int> ForbiddenZonesCount;


### PR DESCRIPTION
The IsEnabled condition in the IPCSubscriber class was updated to check for both "BossMod" and "BossModReborn". This will allow the program to function correctly if either service is ready and available.