### PR TITLE
Turn off BossMod AI when stopping

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -871,6 +871,8 @@ public class AutoDuty : IDalamudPlugin
         Goto = false;
         Repairing = false;
         MainWindow.OpenTab("Main");
+        _chat.ExecuteCommand($"/vbmai off");
+        _chat.ExecuteCommand($"/vbm cfg AIConfig Enable false");
         if (Indexer > 0 && !MainListClicked)
             Indexer = -1;
         if (VNavmesh_IPCSubscriber.Path_GetTolerance() > 0.25F)


### PR DESCRIPTION
When AutoDuty stops, the BossMod AI stays on, which is quite annoying because it does some weird stuff when playing normally.
We should turn it back off once we're done with AutoDuty.