### PR TITLE
Index ARR/HW/SB Dungeons Properly

### DIFF
--- a/AutoDuty/Helpers/ContentHelper.cs
+++ b/AutoDuty/Helpers/ContentHelper.cs
@@ -69,6 +69,10 @@ namespace AutoDuty.Helpers
                 };
                 if (content.DawnContent && listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).Any())
                     content.DawnIndex = listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId < 24 ? (int)listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId : (int)listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId - 200;
+                if (content.ExVersion == 5)
+                {
+                    content.DawnIndex = content.DawnIndex + 200;
+                }
                 DictionaryContent.Add(contentFinderCondition.TerritoryType.Value.RowId, content);
             }
 

--- a/AutoDuty/Helpers/ContentHelper.cs
+++ b/AutoDuty/Helpers/ContentHelper.cs
@@ -68,11 +68,7 @@ namespace AutoDuty.Helpers
                     GCArmyIndex = ListGCArmyContent.FindIndex(gcArmyContent => gcArmyContent == contentFinderCondition.TerritoryType.Value.RowId)
                 };
                 if (content.DawnContent && listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).Any())
-                    content.DawnIndex = listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId < 24 ? (int)listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId : (int)listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId - 200;
-                if (content.ExVersion == 5)
-                {
-                    content.DawnIndex = content.DawnIndex + 200;
-                }
+                    content.DawnIndex = listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId < 32 ? (int)listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId : (int)listDawnContent.Where(dawnContent => dawnContent.Content.Value == contentFinderCondition).First().RowId - 200;
                 DictionaryContent.Add(contentFinderCondition.TerritoryType.Value.RowId, content);
             }
 

--- a/AutoDuty/Managers/DutySupportManager.cs
+++ b/AutoDuty/Managers/DutySupportManager.cs
@@ -34,6 +34,9 @@ namespace AutoDuty.Managers
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 11, 4), "RegisterDutySupport");
             _taskManager.DelayNext("RegisterDutySupport", 50);
             _taskManager.Enqueue(() => indexModifier += DawnStoryCount((nint)addon) - 1, "RegisterDutySupport");
+            _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 11, 5), "RegisterDutySupport");
+            _taskManager.DelayNext("RegisterDutySupport", 50);
+            _taskManager.Enqueue(() => indexModifier += DawnStoryCount((nint)addon) - 1, "RegisterDutySupport");
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 11, content.ExVersion), "RegisterDutySupport");
             _taskManager.DelayNext("RegisterDutySupport", 250);
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 12, DawnStoryIndex(content.DawnIndex, content.ExVersion, indexModifier)), "RegisterDutySupport");

--- a/AutoDuty/Managers/DutySupportManager.cs
+++ b/AutoDuty/Managers/DutySupportManager.cs
@@ -12,6 +12,11 @@ namespace AutoDuty.Managers
     {
         internal unsafe void RegisterDutySupport(ContentHelper.Content content)
         {
+            if (content.ExVersion == 5)
+            {
+                content.DawnIndex = content.DawnIndex + 200;
+            } // THIS FUCKING SUCKS BUT SHOULD MAKE IT WORK IN THE INTERIM, DT DUNGEONS START AT INDEX 23, BUT IT IS LOADING INTO DUTYSUPPORTMANAGER AS -176 AND I DONT KNOW WHY
+
             if (content.DawnIndex < 0)
                 return;
             _taskManager.Enqueue(() => Svc.Log.Info($"Queueing Duty Support: {content.Name}"), "RegisterDutySupport");

--- a/AutoDuty/Managers/DutySupportManager.cs
+++ b/AutoDuty/Managers/DutySupportManager.cs
@@ -48,7 +48,7 @@ namespace AutoDuty.Managers
             _taskManager.Enqueue(() => indexModifier += DawnStoryCount((nint)addon) - 1, "RegisterDutySupport");
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 11, content.ExVersion), "RegisterDutySupport");
             _taskManager.DelayNext("RegisterDutySupport", 250);
-            _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 12, DawnStoryIndex(TempIndex,, content.ExVersion, indexModifier)), "RegisterDutySupport");
+            _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 12, DawnStoryIndex(TempIndex, content.ExVersion, indexModifier)), "RegisterDutySupport");
             _taskManager.DelayNext("RegisterDutySupport", 250);
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 14), "RegisterDutySupport");
             _taskManager.Enqueue(() => GenericHelpers.TryGetAddonByName("ContentsFinderConfirm", out addon) && GenericHelpers.IsAddonReady(addon), "RegisterDutySupport");

--- a/AutoDuty/Managers/DutySupportManager.cs
+++ b/AutoDuty/Managers/DutySupportManager.cs
@@ -12,16 +12,7 @@ namespace AutoDuty.Managers
     {
         internal unsafe void RegisterDutySupport(ContentHelper.Content content)
         {
-            int TempIndex = 0;
-            if (content.ExVersion == 5)
-            {
-                TempIndex = content.DawnIndex + 200;
-            } else
-            {
-                TempIndex = content.DawnIndex;
-            } // THIS FUCKING SUCKS BUT SHOULD MAKE IT WORK IN THE INTERIM, DT DUNGEONS START AT INDEX 23, BUT IT IS LOADING INTO DUTYSUPPORTMANAGER AS -176 AND I DONT KNOW WHY
-
-            if (TempIndex < 0)
+            if (content.DawnIndex < 0)
                 return;
             _taskManager.Enqueue(() => Svc.Log.Info($"Queueing Duty Support: {content.Name}"), "RegisterDutySupport");
             _taskManager.Enqueue(() => AutoDuty.Plugin.Action = $"Step: Queueing Duty Support: {content.Name}", "RegisterDutySupport");
@@ -48,7 +39,7 @@ namespace AutoDuty.Managers
             _taskManager.Enqueue(() => indexModifier += DawnStoryCount((nint)addon) - 1, "RegisterDutySupport");
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 11, content.ExVersion), "RegisterDutySupport");
             _taskManager.DelayNext("RegisterDutySupport", 250);
-            _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 12, DawnStoryIndex(TempIndex, content.ExVersion, indexModifier)), "RegisterDutySupport");
+            _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 12, DawnStoryIndex(content.DawnIndex, content.ExVersion, indexModifier)), "RegisterDutySupport");
             _taskManager.DelayNext("RegisterDutySupport", 250);
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 14), "RegisterDutySupport");
             _taskManager.Enqueue(() => GenericHelpers.TryGetAddonByName("ContentsFinderConfirm", out addon) && GenericHelpers.IsAddonReady(addon), "RegisterDutySupport");

--- a/AutoDuty/Managers/DutySupportManager.cs
+++ b/AutoDuty/Managers/DutySupportManager.cs
@@ -12,12 +12,16 @@ namespace AutoDuty.Managers
     {
         internal unsafe void RegisterDutySupport(ContentHelper.Content content)
         {
+            int TempIndex = 0;
             if (content.ExVersion == 5)
             {
-                content.DawnIndex = content.DawnIndex + 200;
+                TempIndex = content.DawnIndex + 200;
+            } else
+            {
+                TempIndex = content.DawnIndex;
             } // THIS FUCKING SUCKS BUT SHOULD MAKE IT WORK IN THE INTERIM, DT DUNGEONS START AT INDEX 23, BUT IT IS LOADING INTO DUTYSUPPORTMANAGER AS -176 AND I DONT KNOW WHY
 
-            if (content.DawnIndex < 0)
+            if (TempIndex < 0)
                 return;
             _taskManager.Enqueue(() => Svc.Log.Info($"Queueing Duty Support: {content.Name}"), "RegisterDutySupport");
             _taskManager.Enqueue(() => AutoDuty.Plugin.Action = $"Step: Queueing Duty Support: {content.Name}", "RegisterDutySupport");
@@ -44,7 +48,7 @@ namespace AutoDuty.Managers
             _taskManager.Enqueue(() => indexModifier += DawnStoryCount((nint)addon) - 1, "RegisterDutySupport");
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 11, content.ExVersion), "RegisterDutySupport");
             _taskManager.DelayNext("RegisterDutySupport", 250);
-            _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 12, DawnStoryIndex(content.DawnIndex, content.ExVersion, indexModifier)), "RegisterDutySupport");
+            _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 12, DawnStoryIndex(TempIndex,, content.ExVersion, indexModifier)), "RegisterDutySupport");
             _taskManager.DelayNext("RegisterDutySupport", 250);
             _taskManager.Enqueue(() => AddonHelper.FireCallBack(addon, true, 14), "RegisterDutySupport");
             _taskManager.Enqueue(() => GenericHelpers.TryGetAddonByName("ContentsFinderConfirm", out addon) && GenericHelpers.IsAddonReady(addon), "RegisterDutySupport");


### PR DESCRIPTION
This change should fix the indexing issues on older dungeons caused by unlocking the dawntrail expack category when you get your first dawntrail dungeon.

I still don't know why dawntrail dungeons won't even open the gui