### PR TITLE
GetBossObject: search by ID

### DIFF
--- a/AutoDuty/Helpers/ObjectHelper.cs
+++ b/AutoDuty/Helpers/ObjectHelper.cs
@@ -39,7 +39,7 @@ namespace AutoDuty.Helpers
 
         internal static IGameObject? GetObjectByNameAndRadius(string objectName) => Svc.Objects.OrderBy(GetDistanceToPlayer).FirstOrDefault(g => g.Name.TextValue.Equals(objectName, StringComparison.CurrentCultureIgnoreCase) && Vector3.Distance(Player.Object.Position, g.Position) <= 10);
 
-        internal static IBattleChara? GetBossObject(int radius = 100) => GetObjectsByRadius(radius)?.OfType<IBattleChara>().FirstOrDefault(b => IsBossFromIcon(b) || BossMod_IPCSubscriber.HasModule(b));
+        internal static IBattleChara? GetBossObject(int radius = 100) => GetObjectsByRadius(radius)?.OfType<IBattleChara>().FirstOrDefault(b => IsBossFromIcon(b) || BossMod_IPCSubscriber.HasModuleByDataId(b.DataId));
 
         internal unsafe static float GetDistanceToPlayer(IGameObject gameObject) => GetDistanceToPlayer(gameObject.Position);
 

--- a/AutoDuty/IPC/IPCSubscriber.cs
+++ b/AutoDuty/IPC/IPCSubscriber.cs
@@ -19,7 +19,7 @@ namespace AutoDuty.IPC
 
         [EzIPC] internal static readonly Func<bool> IsMoving;
         [EzIPC] internal static readonly Func<int> ForbiddenZonesCount;
-        [EzIPC] internal static readonly Func<IGameObject, bool> HasModule;
+        [EzIPC] internal static readonly Func<uint, bool> HasModuleByDataId;
         [EzIPC] internal static readonly Func<string, bool> ActiveModuleHasComponent;
         [EzIPC] internal static readonly Func<List<string>> ActiveModuleComponentBaseList;
         [EzIPC] internal static readonly Func<List<string>> ActiveModuleComponentList;

--- a/AutoDuty/Managers/ActionsManager.cs
+++ b/AutoDuty/Managers/ActionsManager.cs
@@ -229,7 +229,7 @@ namespace AutoDuty.Managers
                 if (AutoDuty.Plugin.BossObject == null && Svc.Targets.Target != null)
                 {
                     AutoDuty.Plugin.BossObject = (IBattleChara?)Svc.Targets.Target;
-                    hasModule = BossMod_IPCSubscriber.HasModule(AutoDuty.Plugin.BossObject);
+                    hasModule = BossMod_IPCSubscriber.HasModuleByDataId(AutoDuty.Plugin.BossObject!.DataId);
                 }
                 if (BossMod_IPCSubscriber.ForbiddenZonesCount() > numForbiddenZonesToIgnore)
                     FollowHelper.SetFollow(null);
@@ -307,7 +307,7 @@ namespace AutoDuty.Managers
             {
                 if (AutoDuty.Plugin.BossObject != null)
                 {
-                    hasModule = BossMod_IPCSubscriber.HasModule(AutoDuty.Plugin.BossObject);
+                    hasModule = BossMod_IPCSubscriber.HasModuleByDataId(AutoDuty.Plugin.BossObject!.DataId);
                 }
                 else if (Svc.Targets.Target != null)
                 {


### PR DESCRIPTION
apparently some GameObjects can be self-referencing - this actually happened with *every* boss in Ihuykatumu. i don't know if this error is related to the issue of the player getting stuck in combat after boss fights, but even if it isn't, significantly reducing the log spam has to be a good thing either way

```2024-07-12 12:26:40.395 -04:00 [ERR] Exception during raise of Void <InvokeSafely>b__0()
Newtonsoft.Json.JsonSerializationException: Self referencing loop detected for property 'SourceObject' with type 'Dalamud.Game.ClientState.Objects.SubKinds.PlayerCharacter'. Path 'StatusList[0]'.
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.CheckForCircularReference(JsonWriter writer, Object value, JsonProperty property, JsonContract contract, JsonContainerContract containerContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeObject(JsonWriter writer, Object value, JsonObjectContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeList(JsonWriter writer, IEnumerable values, JsonArrayContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.SerializeObject(JsonWriter writer, Object value, JsonObjectContract contract, JsonProperty member, JsonContainerContract collectionContract, JsonProperty containerProperty)
   at Newtonsoft.Json.Serialization.JsonSerializerInternalWriter.Serialize(JsonWriter jsonWriter, Object value, Type objectType)
   at Newtonsoft.Json.JsonSerializer.SerializeInternal(JsonWriter jsonWriter, Object value, Type objectType)
   at Newtonsoft.Json.JsonConvert.SerializeObjectInternal(Object value, Type type, JsonSerializer jsonSerializer)
   at Dalamud.Plugin.Ipc.Internal.CallGateChannel.ConvertObject(Object obj, Type type) in C:\goatsoft\companysecrets\dalamud\\Plugin\Ipc\Internal\CallGateChannel.cs:line 209
   at Dalamud.Plugin.Ipc.Internal.CallGateChannel.CheckAndConvertArgs(Object[] args, MethodInfo methodInfo) in C:\goatsoft\companysecrets\dalamud\\Plugin\Ipc\Internal\CallGateChannel.cs:line 190
   at Dalamud.Plugin.Ipc.Internal.CallGateChannel.InvokeFunc[TRet](Object[] args) in C:\goatsoft\companysecrets\dalamud\\Plugin\Ipc\Internal\CallGateChannel.cs:line 136
   at AutoDuty.Helpers.ObjectHelper.<>c.<GetBossObject>b__10_0(IBattleChara b) in C:\Users\me\source\repos\AutoDuty\AutoDuty\Helpers\ObjectHelper.cs:line 42
   at System.Linq.Enumerable.TryGetFirst[TSource](IEnumerable`1 source, Func`2 predicate, Boolean& found)
   at System.Linq.Enumerable.FirstOrDefault[TSource](IEnumerable`1 source, Func`2 predicate)
   at AutoDuty.Helpers.ObjectHelper.GetBossObject(Int32 radius) in C:\Users\me\source\repos\AutoDuty\AutoDuty\Helpers\ObjectHelper.cs:line 42
   at AutoDuty.AutoDuty.Framework_Update(IFramework framework) in C:\Users\me\source\repos\AutoDuty\AutoDuty\AutoDuty.cs:line 716
   at Dalamud.Utility.EventHandlerExtensions.HandleInvoke(Action act) in C:\goatsoft\companysecrets\dalamud\\Utility\EventHandlerExtensions.cs:line 124```