### PR TITLE
Use Bossmod's new HasModuleByDataId IPC instead

### DIFF
--- a/AutoDuty/Helpers/ObjectHelper.cs
+++ b/AutoDuty/Helpers/ObjectHelper.cs
@@ -39,7 +39,7 @@ namespace AutoDuty.Helpers
 
         internal static IGameObject? GetObjectByNameAndRadius(string objectName) => Svc.Objects.OrderBy(GetDistanceToPlayer).FirstOrDefault(g => g.Name.TextValue.Equals(objectName, StringComparison.CurrentCultureIgnoreCase) && Vector3.Distance(Player.Object.Position, g.Position) <= 10);
 
-        internal static IBattleChara? GetBossObject(int radius = 100) => GetObjectsByRadius(radius)?.OfType<IBattleChara>().FirstOrDefault(b => IsBossFromIcon(b) || BossMod_IPCSubscriber.HasModule(b));
+        internal static IBattleChara? GetBossObject(int radius = 100) => GetObjectsByRadius(radius)?.OfType<IBattleChara>().FirstOrDefault(b => IsBossFromIcon(b) || BossMod_IPCSubscriber.HasModuleByDataId(b.DataId));
 
         internal unsafe static float GetDistanceToPlayer(IGameObject gameObject) => GetDistanceToPlayer(gameObject.Position);
 

--- a/AutoDuty/IPC/IPCSubscriber.cs
+++ b/AutoDuty/IPC/IPCSubscriber.cs
@@ -19,7 +19,7 @@ namespace AutoDuty.IPC
 
         [EzIPC] internal static readonly Func<bool> IsMoving;
         [EzIPC] internal static readonly Func<int> ForbiddenZonesCount;
-        [EzIPC] internal static readonly Func<IGameObject, bool> HasModule;
+        [EzIPC] internal static readonly Func<uint, bool> HasModuleByDataId;
         [EzIPC] internal static readonly Func<string, bool> ActiveModuleHasComponent;
         [EzIPC] internal static readonly Func<List<string>> ActiveModuleComponentBaseList;
         [EzIPC] internal static readonly Func<List<string>> ActiveModuleComponentList;

--- a/AutoDuty/Managers/ActionsManager.cs
+++ b/AutoDuty/Managers/ActionsManager.cs
@@ -229,7 +229,7 @@ namespace AutoDuty.Managers
                 if (AutoDuty.Plugin.BossObject == null && Svc.Targets.Target != null)
                 {
                     AutoDuty.Plugin.BossObject = (IBattleChara?)Svc.Targets.Target;
-                    hasModule = BossMod_IPCSubscriber.HasModule(AutoDuty.Plugin.BossObject);
+                    hasModule = BossMod_IPCSubscriber.HasModuleByDataId(AutoDuty.Plugin.BossObject!.DataId);
                 }
                 if (BossMod_IPCSubscriber.ForbiddenZonesCount() > numForbiddenZonesToIgnore)
                     FollowHelper.SetFollow(null);
@@ -307,12 +307,12 @@ namespace AutoDuty.Managers
             {
                 if (AutoDuty.Plugin.BossObject != null)
                 {
-                    hasModule = BossMod_IPCSubscriber.HasModule(AutoDuty.Plugin.BossObject);
+                    hasModule = BossMod_IPCSubscriber.HasModuleByDataId(AutoDuty.Plugin.BossObject!.DataId);
                 }
                 else if (Svc.Targets.Target != null)
                 {
                     AutoDuty.Plugin.BossObject = (IBattleChara)Svc.Targets.Target;
-                    hasModule = BossMod_IPCSubscriber.HasModule(AutoDuty.Plugin.BossObject);
+                    hasModule = BossMod_IPCSubscriber.HasModuleByDataId(AutoDuty.Plugin.BossObject!.DataId);
                 }
                 if (hasModule)
                 {


### PR DESCRIPTION
The current HasModule implementation of Bossmod has some problems, since Dalamud can't serialize the boss IGameObjects.
See https://github.com/awgil/ffxiv_bossmod/pull/377 for more info.
This fixes the constant errors that the current HasModule method throws.