### PR TITLE
Fix FollowHelper Update being called even when disabled

### DIFF
--- a/AutoDuty/Helpers/FollowHelper.cs
+++ b/AutoDuty/Helpers/FollowHelper.cs
@@ -14,15 +14,19 @@ namespace AutoDuty.Helpers
         private static IGameObject? _followTarget = null;
         private static float _followDistance = 0.25f;
 
+        private static bool _updateHooked = false;
         private static bool _enabled
         {
             get { return _enabled; }    
             set
             {
-                if (value)
+                if (value && !_updateHooked) {
+                    _updateHooked = true;
                     Svc.Framework.Update += FollowUpdate;
-                else
+                }
+                else if (!value && _updateHooked)
                 {
+                    _updateHooked = false;
                     Svc.Framework.Update -= FollowUpdate;
                     InputHelper.SetKeyValue(W, Released);
                 }
@@ -39,7 +43,10 @@ namespace AutoDuty.Helpers
                 _enabled = true;
             }
             else
+            {
+                _followTarget = null;
                 _enabled = false;
+            }
             if (followDistance > 0)
                 _followDistance = followDistance;
         } 


### PR DESCRIPTION
After applying the fix (https://github.com/ffxivcode/AutoDuty/pull/53) about errors from Bossmod's HasModule method, AutoDuty stops working after every boss encounter.
This fixes the problem by ensuring that the FollowHelper's FollowUpdate method is only added to the Framework Update event once and doesn't continue to run when the boss is dead.