### PR TITLE
Alternative Rotation Plugin setting

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -509,7 +509,7 @@ public sealed class AutoDuty : IDalamudPlugin
         _chat.ExecuteCommand($"/vbmai on");
         if (IPCSubscriber_Common.IsReady("BossModReborn") && Configuration.AutoManageBossModAISettings)
             SetBMRSettings();
-        if (Configuration.AutoManageRSRState)
+        if (Configuration.AutoManageRSRState && !Configuration.UsingAlternativeRotationPlugin)
             ReflectionHelper.RotationSolver_Reflection.RotationAuto();
         Svc.Log.Info("Starting Navigation");
         if (startFromZero)
@@ -681,7 +681,7 @@ public sealed class AutoDuty : IDalamudPlugin
         if (!VNavmesh_IPCSubscriber.IsEnabled)
             return;
 
-        if (!ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled)
+        if (!ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled && !Configuration.UsingAlternativeRotationPlugin)
             return;
 
         if (!ObjectHelper.IsValid)
@@ -709,7 +709,7 @@ public sealed class AutoDuty : IDalamudPlugin
             {
                 ExitDuty();
                 Started = false;
-                if (Configuration.AutoManageRSRState)
+                if (Configuration.AutoManageRSRState && !Configuration.UsingAlternativeRotationPlugin)
                     ReflectionHelper.RotationSolver_Reflection.RotationStop();
                 _chat.ExecuteCommand($"/vbmai off");
                 _chat.ExecuteCommand($"/vbm cfg AIConfig Enable false");
@@ -824,7 +824,7 @@ public sealed class AutoDuty : IDalamudPlugin
                 Action = $"{Plugin.ListBoxPOSText[Indexer]}";
                 if (ObjectHelper.InCombat(Player) && Plugin.StopForCombat)
                 {
-                    if (Configuration.AutoManageRSRState)
+                    if (Configuration.AutoManageRSRState && !Configuration.UsingAlternativeRotationPlugin)
                         ReflectionHelper.RotationSolver_Reflection.RotationAuto();
                     VNavmesh_IPCSubscriber.Path_Stop();
                     Stage = 4;
@@ -873,7 +873,7 @@ public sealed class AutoDuty : IDalamudPlugin
                 if (!ObjectHelper.IsReady || Indexer == -1 || Indexer >= ListBoxPOSText.Count)
                     return;
 
-                if (Configuration.AutoManageRSRState)
+                if (Configuration.AutoManageRSRState && !Configuration.UsingAlternativeRotationPlugin)
                     ReflectionHelper.RotationSolver_Reflection.RotationAuto();
 
                 if (!TaskManager.IsBusy)

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -10,6 +10,7 @@ using ECommons.DalamudServices;
 using Lumina.Excel.GeneratedSheets;
 using ECommons;
 using Dalamud.Interface.Utility;
+using Dalamud.Interface.Components;
 
 namespace AutoDuty.Windows;
 
@@ -76,6 +77,7 @@ public class Configuration : IPluginConfiguration
     public bool StopItemQty { get; set; } = false;
     public Dictionary<uint, KeyValuePair<string, int>> StopItemQtyItemDictionary { get; set; } = [];
     public int StopItemQtyInt { get; set; } = 1;
+    public bool UsingAlternativeRotationPlugin;
 
     public Dictionary<uint, Dictionary<Job, int>> PathSelections { get; set; } = [];
 
@@ -130,6 +132,7 @@ public static class ConfigTab
         var stopItemQty = Configuration.StopItemQty;
         var stopItemQtyItemDictionary = Configuration.StopItemQtyItemDictionary;
         var stopItemQtyInt = Configuration.StopItemQtyInt;
+        
 
         if (ImGui.Checkbox("Open Overlay", ref openOverlay))
         {
@@ -246,6 +249,14 @@ public static class ConfigTab
             Configuration.Save();
         }
         ImGui.Separator();
+
+        if (ImGui.Checkbox("Using Alternative Rotation Plugin", ref Configuration.UsingAlternativeRotationPlugin))
+            Configuration.Save();
+
+        ImGuiComponents.HelpMarker("You are deciding to use a plugin other than Rotation Solver.");
+
+        ImGui.Separator();
+
         if (ImGui.Checkbox("AutoRepair Enabled @", ref autoRepair))
         {
             Configuration.AutoRepair = autoRepair;

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -123,7 +123,7 @@ namespace AutoDuty.Windows
                     }
                     if (!ImGui.BeginListBox("##MainList", new Vector2(355 * ImGuiHelpers.GlobalScale, 425 * ImGuiHelpers.GlobalScale))) return;
 
-                    if (VNavmesh_IPCSubscriber.IsEnabled && BossMod_IPCSubscriber.IsEnabled && ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled)
+                    if ((VNavmesh_IPCSubscriber.IsEnabled || Plugin.Configuration.UsingAlternativeMovingPlugin) && (BossMod_IPCSubscriber.IsEnabled || Plugin.Configuration.UsingAlternativeBossPlugin) && (ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled || Plugin.Configuration.UsingAlternativeRotationPlugin))
                     {
                         foreach (var item in Plugin.ListBoxPOSText.Select((name, index) => (name, index)))
                         {
@@ -164,11 +164,11 @@ namespace AutoDuty.Windows
                     }
                     else
                     {
-                        if (!VNavmesh_IPCSubscriber.IsEnabled)
+                        if (!VNavmesh_IPCSubscriber.IsEnabled && !Plugin.Configuration.UsingAlternativeMovingPlugin)
                             ImGui.TextColored(new Vector4(255, 0, 0, 1), "AutoDuty Requires VNavmesh plugin to be Installed and Loaded\nPlease add 3rd party repo:\nhttps://puni.sh/api/repository/veyn");
-                        if (!BossMod_IPCSubscriber.IsEnabled)
+                        if (!BossMod_IPCSubscriber.IsEnabled && !Plugin.Configuration.UsingAlternativeBossPlugin)
                             ImGui.TextColored(new Vector4(255, 0, 0, 1), "AutoDuty Requires BossMod plugin to be Installed and Loaded\nPlease add 3rd party repo:\nhttps://puni.sh/api/repository/veyn");
-                        if (!ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled)
+                        if (!ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled && !Plugin.Configuration.UsingAlternativeRotationPlugin)
                             ImGui.TextColored(new Vector4(255, 0, 0, 1), "AutoDuty Requires Rotation Solver plugin to be Installed and Loaded\nPlease add 3rd party repo:\nhttps://raw.githubusercontent.com/FFXIV-CombatReborn/CombatRebornRepo/main/pluginmaster.json");
                     }
                     ImGui.EndListBox();


### PR DESCRIPTION
Adds an option to disable Rotation Solver as being mandatory for the plugin in favour of using another rotation plugin.