### PR TITLE
Disable bossmod AI when AutoDuty is stopped prematurely

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -1066,6 +1066,8 @@ public sealed class AutoDuty : IDalamudPlugin
         Started = false;
         Stage = 0;
         CurrentLoop = 0;
+        _chat.ExecuteCommand($"/vbmai off");
+        _chat.ExecuteCommand($"/vbm cfg AIConfig Enable false");
         if (Indexer > 0 && !MainListClicked)
             Indexer = -1;
         if (Configuration.OpenOverlay && Configuration.OnlyOpenOverlayWhenRunning)


### PR DESCRIPTION
This disables the VBM/BMR AI when "Stop" is pressed in the UI.