### PR TITLE
add tolerance for last boss room loading in ARF

### DIFF
--- a/AutoDuty/Paths/(1110) The Aetherochemical Research Facility.json
+++ b/AutoDuty/Paths/(1110) The Aetherochemical Research Facility.json
@@ -31,7 +31,7 @@
 	"PausePandora|0, 0, 0|Auto-interact with Objects in Instances|5000",
 	"Interactable|0, 0, 0|2005309 (Lift Terminal)",
     "Wait|228.77, -59.27, 95.07|8000",
-    "AutoMoveFor|227.97, -90.16, 49.87|1000",
+    "AutoMoveFor|227.97, -90.16, 49.87|4000",
     "Boss|230.03, -96.46, -182.83|",
     "AutoMoveFor|0, 0, 0|5000",
     "Boss|229.89, -456.46, 79.02|"


### PR DESCRIPTION
When entering the last boss room of ARF, the script will sometime back out of the room and stop working properly.

This seems to fix this behavior. From what I can infer the number at the end of the path adds a wait period which seems to add tolerance for the loading screen (which I assume is causing the issue).

There's another issue in ARF pathing that would be nice to add some tolerance for but I'm not sure how to go about it. Before the second boss there are two orbs that needs to be forced attack (since they're not aggressive) to open up the path forward. The script sometimes pass them by without attacking them. It could be more likely on casters but I'm not sure.