### PR TITLE
add some tolerance for elevator room loading screen in ARF

### DIFF
--- a/AutoDuty/Paths/(1110) The Aetherochemical Research Facility.json
+++ b/AutoDuty/Paths/(1110) The Aetherochemical Research Facility.json
@@ -10,7 +10,7 @@
     "MoveTo|110.17, 222.05, 270.08|",
     "ForceAttack|110.17, 222.05, 270.08|",
     "Boss|247.25, 225.14, 271.92|",
-    "AutoMoveFor|324.80, 222.20, 271.98|1000",
+    "AutoMoveFor|324.80, 222.20, 271.98|4000",
     "MoveTo|-352.83, -299.98, -249.99|",
 	"PausePandora|0, 0, 0|Auto-interact with Objects in Instances|5000",
 	"Interactable|0, 0, 0|2005307 (Lift Terminal)",


### PR DESCRIPTION
Figured out the source of the bug in elevator in ARF and don't know why it didn't occur to me sooner.

The cause was the same as the last boss room bug : the loading screen being longer than expected.

So, just like with the last boss room problem I made the previous automovefor command longer which as mentioned previously should act as wait for the next command to add some tolerance for the loading screen.

I wonder if it'd be possible for the mod as a whole to detect loading screens and to avoid moving to the next command as long as it is in a loading screen so as to generalize the fix.