### PR TITLE
Auto Equip Fixes

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -308,7 +308,7 @@ public sealed class AutoDuty : IDalamudPlugin
 
                 if (Configuration.AutoEquipRecommendedGear)
                 {
-                    TaskManager.Enqueue(() => AutoEquipHelper.Invoke(TaskManager), "Loop-AutoEquip");
+                    TaskManager.Enqueue(() => AutoEquipHelper.Invoke(), "Loop-AutoEquip");
                     TaskManager.DelayNext("Loop-Delay50", 50);
                     TaskManager.Enqueue(() => !AutoEquipHelper.AutoEquipRunning, int.MaxValue, "Loop-WaitAutoEquipComplete");
                     TaskManager.Enqueue(() => !ObjectHelper.IsOccupied, "Loop-WaitANotIsOccupied");

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -445,10 +445,15 @@ namespace AutoDuty.Windows
                         {
                             ImGui.SameLine();
                             bool leveling = Plugin.Leveling;
+                            bool equip = Plugin.Configuration.AutoEquipRecommendedGear;
                             if (ImGui.Checkbox("Leveling", ref leveling))
                             {
                                 if (leveling)
                                 {
+                                    if (equip){
+                                        AutoEquipHelper.Invoke();
+                                        equip = false;
+                                    }
                                     ContentHelper.Content? duty = LevelingHelper.SelectHighestLevelingRelevantDuty();
                                     if (duty != null)
                                     {


### PR DESCRIPTION
-Removal of Taskmanager requirement from AutoEquipHelper
-Reorganized process to save gearsets only after equipping new gear
-Added functionality to leveling checkbox, when enabled, if AutoEquip is true, will use best available gear PRIOR to searching for appropriate leveling dungeon