### PR TITLE
Config options

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -152,7 +152,10 @@ public sealed class AutoDuty : IDalamudPlugin
 
             if (Configuration.ShowOverlay && (!Configuration.HideOverlayWhenStopped || Started || Running))
                 SchedulerHelper.ScheduleAction("ShowOverlay", () => Overlay.IsOpen = true, () => ObjectHelper.IsReady);
-            
+
+            if (Configuration.ShowMainWindowOnStartup)
+                this.OpenMainUI();
+
             Svc.Commands.AddHandler(CommandName, new CommandInfo(OnCommand)
             {
                 HelpMessage = "\n/autoduty -> opens main window\n" +

--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -430,7 +430,13 @@ public sealed class AutoDuty : IDalamudPlugin
     {
         if (Configuration.TerminationMethodEnum == ConfigTab.TerminationMode.Kill_PC)
         {
-            if(OperatingSystem.IsWindows())
+            if (!Configuration.TerminationKeepActive)
+            {
+                Configuration.TerminationMethodEnum = TerminationMode.Do_Nothing;
+                Configuration.Save();
+            }
+
+            if (OperatingSystem.IsWindows())
             {
                 ProcessStartInfo startinfo = new("shutdown.exe", "-s -t 20");
                 Process.Start(startinfo);
@@ -448,9 +454,23 @@ public sealed class AutoDuty : IDalamudPlugin
             _chat.ExecuteCommand($"/xlkill");
         }
         else if (Configuration.TerminationMethodEnum == ConfigTab.TerminationMode.Kill_Client)
+        {
+            if (!Configuration.TerminationKeepActive)
+            {
+                Configuration.TerminationMethodEnum = TerminationMode.Do_Nothing;
+                Configuration.Save();
+            }
+
             _chat.ExecuteCommand($"/xlkill");
+        }
         else if (Configuration.TerminationMethodEnum == ConfigTab.TerminationMode.Logout)
         {
+            if (!Configuration.TerminationKeepActive)
+            {
+                Configuration.TerminationMethodEnum = TerminationMode.Do_Nothing;
+                Configuration.Save();
+            }
+
             TaskManager.Enqueue(() => ObjectHelper.IsReady);
             TaskManager.DelayNext(2000);
             TaskManager.Enqueue(() => _chat.ExecuteCommand($"/logout"));

--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -31,6 +31,8 @@ using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 using Dalamud.IoC;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using static AutoDuty.Windows.ConfigTab;
+using static FFXIVClientStructs.FFXIV.Common.Component.BGCollision.MeshPCB;
+using System.Diagnostics;
 
 namespace AutoDuty;
 
@@ -426,7 +428,26 @@ public sealed class AutoDuty : IDalamudPlugin
 
     private void LoopsCompleteActions()
     {
-        if (Configuration.TerminationMethodEnum == ConfigTab.TerminationMode.Kill_Client)
+        if (Configuration.TerminationMethodEnum == ConfigTab.TerminationMode.Kill_PC)
+        {
+            if(OperatingSystem.IsWindows())
+            {
+                ProcessStartInfo startinfo = new("shutdown.exe", "-s -t 20");
+                Process.Start(startinfo);
+            } 
+            else if (OperatingSystem.IsLinux())
+            {
+                //Educated guess
+                ProcessStartInfo startinfo = new("shutdown", "-t 20");
+                Process.Start(startinfo);
+            } 
+            else if (OperatingSystem.IsMacOS())
+            {
+                //hell if I know
+            }
+            _chat.ExecuteCommand($"/xlkill");
+        }
+        else if (Configuration.TerminationMethodEnum == ConfigTab.TerminationMode.Kill_Client)
             _chat.ExecuteCommand($"/xlkill");
         else if (Configuration.TerminationMethodEnum == ConfigTab.TerminationMode.Logout)
         {

--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -185,7 +185,7 @@ public sealed class AutoDuty : IDalamudPlugin
             PluginInterface.UiBuilder.OpenMainUi += OpenMainUI;
 
             Svc.Framework.Update += Framework_Update;
-            //Svc.Framework.Update += SchedulerHelper.ScheduleInvoker;
+            Svc.Framework.Update += SchedulerHelper.ScheduleInvoker;
             Svc.ClientState.TerritoryChanged += ClientState_TerritoryChanged;
             Svc.Condition.ConditionChange += Condition_ConditionChange;
         }

--- a/AutoDuty/Paths/(1043) Castrum Meridianum.json
+++ b/AutoDuty/Paths/(1043) Castrum Meridianum.json
@@ -16,7 +16,7 @@
       {
         "version": 114,
         "change": "Added StopForCombat to avoid potentially getting stuck on Fence, and a Wait step for before the boss to avoid leaving duty early"
-      },
+      }
     ],
     "notes": []
   }

--- a/AutoDuty/Paths/(1113) Xelphatol.json
+++ b/AutoDuty/Paths/(1113) Xelphatol.json
@@ -49,7 +49,7 @@
       {
         "version": 114,
         "change": "Fixed Missing Interaction with Lift Lever"
-      },
+      }
     ],
     "notes": []
   }

--- a/AutoDuty/Paths/(1114) Baelsar's Wall.json
+++ b/AutoDuty/Paths/(1114) Baelsar's Wall.json
@@ -52,7 +52,7 @@
       {
         "version": 114,
         "change": "Fixed Missing Interactables"
-      },
+      }
     ],
     "notes": []
   }

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -560,7 +560,7 @@ public static class ConfigTab
                 ImGui.Text("Select Method: ");
                 ImGui.SameLine(0, 5);
                 ImGui.PushItemWidth(150 * ImGuiHelpers.GlobalScale);
-                if (ImGui.BeginCombo(" ", EnumString(Configuration.LootMethodEnum)))
+                if (ImGui.BeginCombo("##ConfigLootMethod", EnumString(Configuration.LootMethodEnum)))
                 {
                     foreach (LootMethod lootMethod in Enum.GetValues(typeof(LootMethod)))
                     {
@@ -916,7 +916,7 @@ public static class ConfigTab
             ImGui.Text("On Completion of All Loops: ");
             ImGui.SameLine(0, 10);
             ImGui.PushItemWidth(150 * ImGuiHelpers.GlobalScale);
-            if (ImGui.BeginCombo(" ", EnumString(Configuration.TerminationMethodEnum)))
+            if (ImGui.BeginCombo("##ConfigTerminationMethod", EnumString(Configuration.TerminationMethodEnum)))
             {
                 foreach (TerminationMode terminationMode in Enum.GetValues(typeof(TerminationMode)))
                 {

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -430,7 +430,8 @@ public static class ConfigTab
         Do_Nothing = 0,
         Logout = 1,
         Start_AR_Multi_Mode =2, 
-        Kill_Client = 3
+        Kill_Client = 3,
+        Kill_PC = 4
     }
     public enum Role : int
     {
@@ -920,11 +921,12 @@ public static class ConfigTab
             {
                 foreach (TerminationMode terminationMode in Enum.GetValues(typeof(TerminationMode)))
                 {
-                    if (ImGui.Selectable(EnumString(terminationMode)))
-                    {
-                        Configuration.TerminationMethodEnum = terminationMode;
-                        Configuration.Save();
-                    }
+                    if (terminationMode != TerminationMode.Kill_PC || (OperatingSystem.IsWindows() || OperatingSystem.IsLinux()))
+                        if (ImGui.Selectable(EnumString(terminationMode)))
+                        {
+                            Configuration.TerminationMethodEnum = terminationMode;
+                            Configuration.Save();
+                        }
                 }
                 ImGui.EndCombo();
             }       

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -238,25 +238,9 @@ public class Configuration : IPluginConfiguration
     public int AutoRepairPct = 50;
     internal bool autoRepairSelf = false;
     public bool AutoRepairSelf 
-    { 
-        get => autoRepairSelf; 
-        set
-        {
-            autoRepairSelf = value;
-            if (value)
-                AutoRepairCity = false;
-        }
-    }
-    internal bool autoRepairCity = true;
-    public bool AutoRepairCity
     {
-        get => autoRepairCity;
-        set
-        {
-            autoRepairCity = value;
-            if (value)
-                AutoRepairSelf = false;
-        }
+        get => autoRepairSelf; 
+        set => autoRepairSelf = value;
     }
 
     //Between Loop Config Options
@@ -659,30 +643,44 @@ public static class ConfigTab
                 Configuration.Save();
             ImGuiComponents.HelpMarker("Will use Boiled Eggs in inventory for +3% Exp.");
 
+            if (ImGui.Checkbox("Auto Repair", ref Configuration.AutoRepair)) 
+                Configuration.Save();
 
-            if (ImGui.Checkbox("Auto Repair via Self", ref Configuration.autoRepairSelf))
+            using (ImRaii.Disabled(!Configuration.AutoRepair))
             {
-                Configuration.AutoRepairSelf = Configuration.autoRepairSelf;
-                Configuration.Save();
-            }
-            ImGuiComponents.HelpMarker("Will use DarkMatter to Self Repair (Requires Leveled Crafters!)");
-            if (ImGui.Checkbox("Auto Repair via CityNpc", ref Configuration.autoRepairCity))
-            {
-                Configuration.AutoRepairCity = Configuration.autoRepairCity;
-                Configuration.Save();
-            }
-            ImGuiComponents.HelpMarker("Will use Npc near Inn to Repair.");
-            using (var d1 = ImRaii.Disabled(!Configuration.autoRepairSelf && !Configuration.autoRepairCity))
-            {
-                if (ImGui.Checkbox("Trigger Auto Repair @", ref Configuration.AutoRepair))
+                ImGui.SameLine();
+
+                bool selfRepair = Configuration.autoRepairSelf;
+
+                if (ImGui.RadioButton("Self", selfRepair))
+                {
+                    Configuration.AutoRepairSelf = true;
                     Configuration.Save();
+                }
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker("Will use DarkMatter to Self Repair (Requires Leveled Crafters!)");
+                ImGui.SameLine();
+                
+                bool cityRepair = !Configuration.autoRepairSelf;
+                if (ImGui.RadioButton("CityNpc", !selfRepair))
+                {
+                    Configuration.AutoRepairSelf = false;
+                    Configuration.Save();
+                }
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker("Will use Npc near Inn to Repair.");
+            }
 
-                ImGui.SameLine(0, 5);
+            using (var d1 = ImRaii.Disabled(!Configuration.AutoRepair))
+            {
+                ImGui.Indent();
+                ImGui.Text("Trigger @");
+                ImGui.SameLine();
                 ImGui.PushItemWidth(150 * ImGuiHelpers.GlobalScale);
                 if (ImGui.SliderInt("##Repair@", ref Configuration.AutoRepairPct, 1, 99, "%d%%"))
                     Configuration.Save();
                 ImGui.PopItemWidth();
-
+                ImGui.Unindent();
             }
         }
 

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -164,7 +164,8 @@ public class Configuration : IPluginConfiguration
     }
     public bool Unsynced = false;
     public bool HideUnavailableDuties = false;
-    
+
+    public bool ShowMainWindowOnStartup = false;
     //Overlay Config Options
     public bool ShowOverlay = true;
     internal bool hideOverlayWhenStopped = false;
@@ -467,40 +468,48 @@ public static class ConfigTab
 
         if (overlayHeaderSelected == true)
         {
+            ImGui.Columns(2, "##OverlayColumns", false);
+
             if (ImGui.Checkbox("Show Overlay", ref Configuration.ShowOverlay))
                 Configuration.Save();
 
             using (var openOverlayDisable = ImRaii.Disabled(!Configuration.ShowOverlay))
             {
-                ImGui.SameLine(0, 53);
+                ImGui.NextColumn();
+
+                //ImGui.SameLine(0, 53);
                 if (ImGui.Checkbox("Hide When Stopped", ref Configuration.hideOverlayWhenStopped))
                 {
                     Configuration.HideOverlayWhenStopped = Configuration.hideOverlayWhenStopped;
                     Configuration.Save();
                 }
-
+                ImGui.NextColumn();
                 if (ImGui.Checkbox("Lock Overlay", ref Configuration.lockOverlay))
                 {
                     Configuration.LockOverlay = Configuration.lockOverlay;
                     Configuration.Save();
                 }
-                ImGui.SameLine(0, 57);
+                ImGui.NextColumn();
+                //ImGui.SameLine(0, 57);
                 if (ImGui.Checkbox("Use Transparent BG", ref Configuration.overlayNoBG))
                 {
                     Configuration.OverlayNoBG = Configuration.overlayNoBG;
                     Configuration.Save();
                 }
-
+                ImGui.NextColumn();
                 if (ImGui.Checkbox("Show Duty/Loops Text", ref Configuration.ShowDutyLoopText))
                     Configuration.Save();
-
-                ImGui.SameLine(0, 5);
+                ImGui.NextColumn();
                 if (ImGui.Checkbox("Show AD Action Text", ref Configuration.ShowActionText))
                     Configuration.Save();
-                
+                ImGui.NextColumn();
                 if (ImGui.Checkbox("Use Slider Inputs", ref Configuration.UseSliderInputs))
                     Configuration.Save();
+                ImGui.Columns(1);
             }
+
+            if (ImGui.Checkbox("Show Main Window on Startup", ref Configuration.ShowMainWindowOnStartup))
+                Configuration.Save();
         }
 
         //Start of Duty Config Settings

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -320,6 +320,7 @@ public class Configuration : IPluginConfiguration
     public Dictionary<uint, KeyValuePair<string, int>> StopItemQtyItemDictionary = [];
     public int StopItemQtyInt = 1;
     public TerminationMode TerminationMethodEnum = TerminationMode.Do_Nothing;
+    public bool TerminationKeepActive = true;
 
     //BMAI Config Options
     public bool HideBossModAIConfig = false;
@@ -929,7 +930,15 @@ public static class ConfigTab
                         }
                 }
                 ImGui.EndCombo();
-            }       
+            }
+
+            if (Configuration.TerminationMethodEnum is TerminationMode.Kill_Client or TerminationMode.Kill_PC or TerminationMode.Logout)
+            {
+                ImGui.Indent();
+                if(ImGui.Checkbox("Keep Termination option after execution ", ref Configuration.TerminationKeepActive))
+                    Configuration.Save();
+                ImGui.Unindent();
+            }
         }     
     }
 


### PR DESCRIPTION
Fixing termination dropdown by giving it a unique identifier
Added termination mode "Kill PC" to shutdown the PC after 20s. Enabled for Windows and Linux.
Auto Repair options streamlined to not go into invalid cases seemingly. Removed internal repair with city npc, as it is unused.
Added Show Main Tab on startup option.

Minor syntax fixes for 3 paths.
Enabling Scheduler again.