### PR TITLE
Trust level fixes

### DIFF
--- a/AutoDuty/Helpers/LevelingHelper.cs
+++ b/AutoDuty/Helpers/LevelingHelper.cs
@@ -44,7 +44,7 @@ namespace AutoDuty.Helpers
 
             if (trust)
             {
-                if (TrustManager.members.Any(tm => tm.Value.Level <= 0)) 
+                if (TrustManager.members.All(tm => tm.Value.Level <= 0)) 
                     return null;
 
 

--- a/AutoDuty/Managers/TrustManager.cs
+++ b/AutoDuty/Managers/TrustManager.cs
@@ -112,7 +112,7 @@ namespace AutoDuty.Managers
                     CombatRole.Healer => healers == 1,
                     CombatRole.Tank => tanks == 1,
                     _ => false
-                };
+                } || trustMembers.Any(tm => tm.Level < AutoDuty.Plugin.CurrentTerritoryContent?.ClassJobLevelRequired);
 
                 if (needsReset)
                 {

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -348,9 +348,9 @@ namespace AutoDuty.Windows
 
                         if (Plugin.Configuration.Trust)
                         {
+                            ImGui.Separator();
                             if (_dutySelected != null && _dutySelected.Content.TrustMembers.Count > 0)
                             {
-                                ImGui.Separator();
                                 ImGuiEx.LineCentered(() => ImGuiEx.TextUnderlined("Select your Trust Party"));
                                 ImGui.Columns(3, null, false);
 
@@ -381,7 +381,7 @@ namespace AutoDuty.Windows
 
                                         bool canSelect = members.CanSelectMember(member, playerRole) && member.Level >= _dutySelected.Content.ClassJobLevelRequired;
 
-                                        using (var disabled = ImRaii.Disabled(!enabled && (numberSelected == 3 || !canSelect)))
+                                        using (ImRaii.Disabled(!enabled && (numberSelected == 3 || !canSelect)))
                                         {
                                             if (ImGui.Checkbox($"###{member.Index}{_dutySelected.id}", ref enabled))
                                             {
@@ -433,6 +433,9 @@ namespace AutoDuty.Windows
                                     TrustManager.ClearCachedLevels();
                                 ImGui.NextColumn();
                                 ImGui.Columns(1, null, true);
+                            } else if (ImGui.Button("Refresh trust member levels"))
+                            {
+                                TrustManager.ClearCachedLevels();
                             }
                         }
 


### PR DESCRIPTION
- Trust not blocked when not all members are available yet
- trust group resetting if selected duty is too high
- MainTab trust member refresh without member list visible