### PR TITLE
Interact Loop Issue Fix

### DIFF
--- a/AutoDuty/Managers/ActionsManager.cs
+++ b/AutoDuty/Managers/ActionsManager.cs
@@ -257,9 +257,13 @@ namespace AutoDuty.Managers
             _taskManager.Enqueue(() => InteractableCheck(gameObject), "Interactable");
             _taskManager.Enqueue(() => Player.Character->IsCasting, 500, "Interactable");
             _taskManager.Enqueue(() => !Player.Character->IsCasting, "Interactable");
+            _taskManager.DelayNext(100);
             _taskManager.Enqueue(() =>
             {
-                if ((bool)!gameObject?.IsTargetable)
+                if ((bool)!gameObject?.IsTargetable ||
+                Svc.Condition[ConditionFlag.BetweenAreas] || 
+                Svc.Condition[ConditionFlag.BetweenAreas51] || 
+                gameObject!?.ObjectKind != Dalamud.Game.ClientState.Objects.Enums.ObjectKind.EventObj)
                 {
                     AutoDuty.Plugin.Action = "";
                 }


### PR DESCRIPTION
No longer loops if you're between areas (i.e used a teleporter) or if the object isn't an event object (such as NPCs)