### PR TITLE
Added Config:

### DIFF
--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -236,6 +236,7 @@ public class Configuration : IPluginConfiguration
             HideBossModAIConfig = !value;
         }
     }
+    public bool AutoManageVnavAlignCamera = true;
     public bool LootTreasure = true;
     public LootMethod LootMethodEnum = LootMethod.AutoDuty;
     public bool LootBossTreasureOnly = false;
@@ -499,8 +500,13 @@ public static class ConfigTab
             if (ImGui.Checkbox("Auto Manage BossMod AI Settings", ref Configuration.autoManageBossModAISettings))
                 Configuration.Save();
             ImGuiComponents.HelpMarker("Autoduty will enable BMAI and any options you configure at the start of each duty.");
-            //ImGui.SameLine(0, 5);
+
+            if (ImGui.Checkbox("Auto Manage Vnav Align Camera", ref Configuration.AutoManageVnavAlignCamera))
+                Configuration.Save();
+            ImGuiComponents.HelpMarker("Autoduty will enable AlignCamera in VNav at the start of each duty, and disable it when done if it was not set.");
             
+            //ImGui.SameLine(0, 5);
+
             if (Configuration.autoManageBossModAISettings == true)
             {
                 var followRole = Configuration.FollowRole;

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -143,7 +143,7 @@ namespace AutoDuty.Windows
                                 ImGui.TextColored(new Vector4(0, 255f, 0, 1), $"{Plugin.Action}");
                             }
                         }
-                        if (!ImGui.BeginListBox("##MainList", new Vector2(355 * ImGuiHelpers.GlobalScale, 425 * ImGuiHelpers.GlobalScale))) return;
+                        if (!ImGui.BeginListBox("##MainList", new Vector2(325 * ImGuiHelpers.GlobalScale, 375 * ImGuiHelpers.GlobalScale))) return;
 
                         if ((VNavmesh_IPCSubscriber.IsEnabled || Plugin.Configuration.UsingAlternativeMovementPlugin) && (BossMod_IPCSubscriber.IsEnabled || Plugin.Configuration.UsingAlternativeBossPlugin) && (ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled || Plugin.Configuration.UsingAlternativeRotationPlugin))
                         {
@@ -283,7 +283,7 @@ namespace AutoDuty.Windows
                             Plugin.Configuration.Save();
                         }
                     }
-                    ImGui.SameLine(0, 5);
+                    //ImGui.SameLine(0, 5);
                     if (ImGui.Checkbox("Trial", ref Plugin.Configuration.trial))
                     {
                         if (Plugin.Configuration.trial)
@@ -293,7 +293,7 @@ namespace AutoDuty.Windows
                             Plugin.Configuration.Save();
                         }
                     }
-                    //ImGui.SameLine(0, 5);
+                    ImGui.SameLine(0, 5);
                     if (ImGui.Checkbox("Raid", ref Plugin.Configuration.raid))
                     {
                         if (Plugin.Configuration.raid)
@@ -466,7 +466,7 @@ namespace AutoDuty.Windows
                             Plugin.Configuration.Save();
                     }
                     
-                    if (!ImGui.BeginListBox("##DutyList", new Vector2(355 * ImGuiHelpers.GlobalScale, 425 * ImGuiHelpers.GlobalScale))) return;
+                    if (!ImGui.BeginListBox("##DutyList", new Vector2(325 * ImGuiHelpers.GlobalScale, 375 * ImGuiHelpers.GlobalScale))) return;
 
                     if (leveling)
                         ImGui.TextColored(new Vector4(0, 1, 0, 1), "Leveling Mode:\nAutoDuty will automatically select the best dungeon");

--- a/AutoDuty/Windows/MainWindow.cs
+++ b/AutoDuty/Windows/MainWindow.cs
@@ -330,7 +330,7 @@ public class MainWindow : Window, IDisposable
             return data[0];
         }
     }
-    public static void EzTabBar(string id, string KoFiTransparent, string openTabName, ImGuiTabBarFlags flags, params (string name, Action function, Vector4? color, bool child)[] tabs)
+    public static void EzTabBar(string id, string? KoFiTransparent, string openTabName, ImGuiTabBarFlags flags, params (string name, Action function, Vector4? color, bool child)[] tabs)
     {
         ImGui.BeginTabBar(id, flags);
         foreach (var x in tabs)
@@ -363,7 +363,7 @@ public class MainWindow : Window, IDisposable
         ImGui.EndTabBar();
     }
 
-    private static List<(string, Action, Vector4?, bool)> tabList =
+    private static readonly List<(string, Action, Vector4?, bool)> tabList =
         [("Main", MainTab.Draw, null, false), ("Build", BuildTab.Draw, null, false), ("Paths", PathsTab.Draw, null, false), ("Config", ConfigTab.Draw, null, false), ("Info", InfoTab.Draw, null, false), ("Support AutoDuty", KofiLink, ImGui.ColorConvertU32ToFloat4(ColorNormal), false)
         ];
 


### PR DESCRIPTION
Auto Manage Vnav Align Camera
- Turns on Align Camera at the start of navigation and if it was off to begin with will turn it back off at the end of loops or on Stop Modified AutoMoveFor to now set Movement Mode to Standard (if it wasnt already) and back(if it was Legacy)