### PR TITLE
Added Config:

### DIFF
--- a/AutoDuty/Helpers/ObjectHelper.cs
+++ b/AutoDuty/Helpers/ObjectHelper.cs
@@ -1,7 +1,6 @@
 ﻿using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.Objects.Types;
 using ECommons.DalamudServices;
-using ECommons.GameHelpers;
 using ECommons.GameFunctions;
 using Lumina.Excel.GeneratedSheets;
 using System.Collections.Generic;

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -241,6 +241,7 @@ public class Configuration : IPluginConfiguration
     public LootMethod LootMethodEnum = LootMethod.AutoDuty;
     public bool LootBossTreasureOnly = false;
     public int TreasureCofferScanDistance = 25;
+    public bool OverridePartyValidation = false;
     public bool UsingAlternativeRotationPlugin = false;
     public bool UsingAlternativeMovementPlugin = false;
     public bool UsingAlternativeBossPlugin = false;
@@ -690,7 +691,12 @@ public static class ConfigTab
                 }
                 ImGui.Unindent();
             }
-            ImGuiComponents.HelpMarker("AutoDuty will ignore all non-boss chests, and only loot boss chests. (Only works with AD Looting)");         
+            ImGuiComponents.HelpMarker("AutoDuty will ignore all non-boss chests, and only loot boss chests. (Only works with AD Looting)");
+
+            if (ImGui.Checkbox("Override Party Validation", ref Configuration.OverridePartyValidation))
+                Configuration.Save();
+            ImGuiComponents.HelpMarker("AutoDuty will ignore your party makeup when queueing for duties\nThis is for Multi-Boxing Only\n*AutoDuty is not recommended to be used with other players*");
+
             /*/
         disabled for now
             using (var d0 = ImRaii.Disabled(true))

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -212,9 +212,9 @@ namespace AutoDuty.Windows
                                 MainWindow.ShowPopup("Error", "You must select a version\nof the dungeon to run");
                             else if (Svc.Party.PartyId > 0 && (Plugin.Configuration.Support || Plugin.Configuration.Squadron || Plugin.Configuration.Trust))
                                 MainWindow.ShowPopup("Error", "You must not be in a party to run Support, Squadron or Trust");
-                            else if (Svc.Party.PartyId == 0 && Plugin.Configuration.Regular && !Plugin.Configuration.Unsynced)
+                            else if (Plugin.Configuration.Regular && !Plugin.Configuration.Unsynced && !Plugin.Configuration.OverridePartyValidation && Svc.Party.PartyId == 0)
                                 MainWindow.ShowPopup("Error", "You must be in a group of 4 to run Regular Duties");
-                            else if (Plugin.Configuration.Regular && !Plugin.Configuration.Unsynced && !ObjectHelper.PartyValidation())
+                            else if (Plugin.Configuration.Regular && !Plugin.Configuration.Unsynced && !Plugin.Configuration.OverridePartyValidation && !ObjectHelper.PartyValidation())
                                 MainWindow.ShowPopup("Error", "You must have the correct party makeup to run Regular Duties");
                             else if (ContentPathsManager.DictionaryPaths.ContainsKey(Plugin.CurrentTerritoryContent?.TerritoryType ?? 0))
                                 Plugin.Run();


### PR DESCRIPTION
Override Party Validation
- AutoDuty will ignore your party makeup when queueing for duties 
- This is for Multi-Boxing Only
- *AutoDuty is not recommended to be used with other players*