### PR TITLE
End Of Loop Audio

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -521,6 +521,10 @@ public sealed class AutoDuty : IDalamudPlugin
 
     private void LoopsCompleteActions()
     {
+        if (Configuration.PlayEndSound)
+        {
+            SoundHelper.StartSound(Configuration.PlayEndSound, Configuration.CustomSound, Configuration.SoundEnum);
+        }
         if (Configuration.TerminationMethodEnum == TerminationMode.Kill_PC)
         {
             if (!Configuration.TerminationKeepActive)

--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -150,6 +150,7 @@ public sealed class AutoDuty : IDalamudPlugin
             ECommonsMain.Init(PluginInterface, this, Module.DalamudReflector, Module.ObjectFunctions);
 
             Configuration = PluginInterface.GetPluginConfig() as Configuration ?? new Configuration();
+            SoundHelper.UpdateAudio(Configuration.PlayEndSound, Configuration.CustomSound, Configuration.SoundPath, Configuration.CustomSoundVolume);
 
             _configDirectory = PluginInterface.ConfigDirectory;
             PathsDirectory = new(_configDirectory.FullName + "/paths");

--- a/AutoDuty/AutoDuty.csproj
+++ b/AutoDuty/AutoDuty.csproj
@@ -32,6 +32,7 @@
   <ItemGroup>
     <ProjectReference Include="..\ECommons\ECommons\ECommons.csproj" />
     <PackageReference Include="DalamudPackager" Version="2.1.13" />
+    <PackageReference Include="NAudio" Version="2.2.1" />
     <PackageReference Include="TinyIpc" Version="4.3.1" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>

--- a/AutoDuty/Data/Enum.cs
+++ b/AutoDuty/Data/Enum.cs
@@ -97,5 +97,55 @@
             Navigating = 1,
             Other = 2
         }
+
+        public enum Sounds : byte
+        {
+            None = 0x00,
+            Unknown = 0x01,
+            Sound01 = 0x25,
+            Sound02 = 0x26,
+            Sound03 = 0x27,
+            Sound04 = 0x28,
+            Sound05 = 0x29,
+            Sound06 = 0x2A,
+            Sound07 = 0x2B,
+            Sound08 = 0x2C,
+            Sound09 = 0x2D,
+            Sound10 = 0x2E,
+            Sound11 = 0x2F,
+            Sound12 = 0x30,
+            Sound13 = 0x31,
+            Sound14 = 0x32,
+            Sound15 = 0x33,
+            Sound16 = 0x34,
+        }
+    }
+}
+
+public static class SoundsExtensions
+{
+    public static string ToName(this Sounds value)
+    {
+        return value switch
+        {
+            Sounds.None => "None",
+            Sounds.Sound01 => "Sound Effect 1",
+            Sounds.Sound02 => "Sound Effect 2",
+            Sounds.Sound03 => "Sound Effect 3",
+            Sounds.Sound04 => "Sound Effect 4",
+            Sounds.Sound05 => "Sound Effect 5",
+            Sounds.Sound06 => "Sound Effect 6",
+            Sounds.Sound07 => "Sound Effect 7",
+            Sounds.Sound08 => "Sound Effect 8",
+            Sounds.Sound09 => "Sound Effect 9",
+            Sounds.Sound10 => "Sound Effect 10",
+            Sounds.Sound11 => "Sound Effect 11",
+            Sounds.Sound12 => "Sound Effect 12",
+            Sounds.Sound13 => "Sound Effect 13",
+            Sounds.Sound14 => "Sound Effect 14",
+            Sounds.Sound15 => "Sound Effect 15",
+            Sounds.Sound16 => "Sound Effect 16",
+            _ => "Unknown",
+        };
     }
 }

--- a/AutoDuty/Helpers/SoundHelper.cs
+++ b/AutoDuty/Helpers/SoundHelper.cs
@@ -1,0 +1,72 @@
+﻿using ECommons.DalamudServices;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using NAudio.Wave;
+using System;
+
+namespace AutoDuty.Helpers
+{
+    public static class SoundHelper
+    {
+        private static AudioFileReader? _audioFile;
+        private static WaveOutEvent? _audioEvent;
+
+        public static bool SoundReady
+            => _audioFile != null && _audioEvent != null;
+
+        public static bool StartSound(bool PlayEndSound, bool CustomSound, Sounds SoundEnum = Sounds.None)
+        {
+            if (!PlayEndSound)
+                return false;
+
+            if (CustomSound)
+            {
+                if (_audioFile == null || _audioEvent == null)
+                {
+                    Svc.Log.Error("AudioFileAudioEventNull.");
+                    return false;
+                }
+
+                _audioEvent!.Stop();
+                _audioFile!.Position = 0;
+                _audioEvent!.Play();
+                //Svc.Log.Error("DidYouHearAnything?");
+                return true;
+            }
+
+            UIModule.PlaySound((uint)SoundEnum);
+            return true;
+        }
+
+        public static void DisposeAudio()
+        {
+            _audioFile?.Dispose();
+            _audioFile = null;
+            _audioEvent?.Dispose();
+            _audioEvent = null;
+        }
+
+        public static void UpdateAudio(bool PlayEndSound, bool CustomSound, string SoundPath, float CustomSoundVolume = 0.5f)
+        {
+            if (!(PlayEndSound && CustomSound))
+            {
+                DisposeAudio();
+                return;
+            }
+
+            try
+            {
+                if (_audioFile?.FileName != SoundPath)
+                    DisposeAudio();
+
+                _audioFile = new AudioFileReader(SoundPath) { Volume = CustomSoundVolume };
+                _audioEvent = new WaveOutEvent();
+                _audioEvent.Init(_audioFile);
+            }
+            catch (Exception ex)
+            {
+                //Dalamud.Log.Error(ex, "Error attempting to setup sound.");
+                DisposeAudio();
+            }
+        }
+    }
+}

--- a/AutoDuty/Paths/(1047) The Howling Eye.json
+++ b/AutoDuty/Paths/(1047) The Howling Eye.json
@@ -1,0 +1,10 @@
+{
+  "actions": [
+    "Boss|0.30, -1.86, -6.43|"
+  ],
+  "meta": {
+    "createdAt": 127,
+    "changelog": [],
+    "notes": []
+  }
+}

--- a/AutoDuty/packages.lock.json
+++ b/AutoDuty/packages.lock.json
@@ -8,6 +8,20 @@
         "resolved": "2.1.13",
         "contentHash": "rMN1omGe8536f4xLMvx9NwfvpAc9YFFfeXJ1t4P4PE6Gu8WCIoFliR1sh07hM+bfODmesk/dvMbji7vNI+B/pQ=="
       },
+      "NAudio": {
+        "type": "Direct",
+        "requested": "[2.2.1, )",
+        "resolved": "2.2.1",
+        "contentHash": "c0DzwiyyklM0TP39Y7RObwO3QkWecgM6H60ikiEnsV/aEAJPbj5MFCLaD8BSfKuZe0HGuh9GRGWWlJmSxDc9MA==",
+        "dependencies": {
+          "NAudio.Asio": "2.2.1",
+          "NAudio.Core": "2.2.1",
+          "NAudio.Midi": "2.2.1",
+          "NAudio.Wasapi": "2.2.1",
+          "NAudio.WinForms": "2.2.1",
+          "NAudio.WinMM": "2.2.1"
+        }
+      },
       "TinyIpc": {
         "type": "Direct",
         "requested": "[4.3.1, )",
@@ -73,10 +87,85 @@
         "resolved": "17.6.3",
         "contentHash": "N0ZIanl1QCgvUumEL1laasU0a7sOE5ZwLZVTn0pAePnfhq8P7SvTjF8Axq+CnavuQkmdQpGNXQ1efZtu5kDFbA=="
       },
+      "Microsoft.NETCore.Platforms": {
+        "type": "Transitive",
+        "resolved": "3.1.0",
+        "contentHash": "z7aeg8oHln2CuNulfhiLYxCVMPEwBl3rzicjvIX+4sUuCwvXw5oXQEtbiU2c0z4qYL5L3Kmx0mMA/+t/SbY67w=="
+      },
+      "Microsoft.Win32.Registry": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "KSrRMb5vNi0CWSGG1++id2ZOs/1QhRqROt+qgbEAdQuGjGrFcl4AOl4/exGPUYz2wUnU42nvJqon1T3U0kPXLA==",
+        "dependencies": {
+          "System.Security.AccessControl": "4.7.0",
+          "System.Security.Principal.Windows": "4.7.0"
+        }
+      },
+      "NAudio.Asio": {
+        "type": "Transitive",
+        "resolved": "2.2.1",
+        "contentHash": "hQglyOT5iT3XuGpBP8ZG0+aoqwRfidHjTNehpoWwX0g6KJEgtH2VaqM2nuJ2mheKZa/IBqB4YQTZVvrIapzfOA==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "4.7.0",
+          "NAudio.Core": "2.2.1"
+        }
+      },
+      "NAudio.Core": {
+        "type": "Transitive",
+        "resolved": "2.2.1",
+        "contentHash": "GgkdP6K/7FqXFo7uHvoqGZTJvW4z8g2IffhOO4JHaLzKCdDOUEzVKtveoZkCuUX8eV2HAINqi7VFqlFndrnz/g=="
+      },
+      "NAudio.Midi": {
+        "type": "Transitive",
+        "resolved": "2.2.1",
+        "contentHash": "6r23ylGo5aeP02WFXsPquz0T0hFJWyh+7t++tz19tc3Kr38NHm+Z9j+FiAv+xkH8tZqXJqus9Q8p6u7bidIgbw==",
+        "dependencies": {
+          "NAudio.Core": "2.2.1"
+        }
+      },
+      "NAudio.Wasapi": {
+        "type": "Transitive",
+        "resolved": "2.2.1",
+        "contentHash": "lFfXoqacZZe0WqNChJgGYI+XV/n/61LzPHT3C1CJp4khoxeo2sziyX5wzNYWeCMNbsWxFvT3b3iXeY1UYjBhZw==",
+        "dependencies": {
+          "NAudio.Core": "2.2.1"
+        }
+      },
+      "NAudio.WinForms": {
+        "type": "Transitive",
+        "resolved": "2.2.1",
+        "contentHash": "DlDkewY1myY0A+3NrYRJD+MZhZV0yy1mNF6dckB27IQ9XCs/My5Ip8BZcoSHOsaPSe2GAjvoaDnk6N9w8xTv7w==",
+        "dependencies": {
+          "NAudio.WinMM": "2.2.1"
+        }
+      },
+      "NAudio.WinMM": {
+        "type": "Transitive",
+        "resolved": "2.2.1",
+        "contentHash": "xFHRFwH4x6aq3IxRbewvO33ugJRvZFEOfO62i7uQJRUNW2cnu6BeBTHUS0JD5KBucZbHZaYqxQG8dwZ47ezQuQ==",
+        "dependencies": {
+          "Microsoft.Win32.Registry": "4.7.0",
+          "NAudio.Core": "2.2.1"
+        }
+      },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      },
+      "System.Security.AccessControl": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "JECvTt5aFF3WT3gHpfofL2MNNP6v84sxtXxpqhLBCcDRzqsPBmHhQ6shv4DwwN2tRlzsUxtb3G9M3763rbXKDg==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "3.1.0",
+          "System.Security.Principal.Windows": "4.7.0"
+        }
+      },
+      "System.Security.Principal.Windows": {
+        "type": "Transitive",
+        "resolved": "4.7.0",
+        "contentHash": "ojD0PX0XhneCsUbAZVKdb7h/70vyYMDYs85lwEI+LngEONe/17A0cFaRFqZU+sOEidcVswYWikYOQ9PPfjlbtQ=="
       },
       "ecommons": {
         "type": "Project"


### PR DESCRIPTION
Added end of loop audio configuration.
Supports in-game sounds for the average user. Limitation of in-game sounds is that they play on the System Sounds channel. 
As an alternative so that sounds still play when you have the Master/SystemSounds muted, I added NAudio with the option to enter a custom sound file path. These sounds will play even when you have the prior sound channels muted in game. 
(Also sneaking in a Howling Eye path for Questionable future use)