### PR TITLE
fix indexer iterating during conditionchange after revive

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -399,7 +399,7 @@ public sealed class AutoDuty : IDalamudPlugin
     {
         if (Stage == Stage.Stopped) return;
         //Svc.Log.Debug($"{flag} : {value}");
-        if (Stage != Stage.Dead && !_recentlyWatchedCutscene && !Conditions.IsWatchingCutscene && flag != ConditionFlag.WatchingCutscene && flag != ConditionFlag.WatchingCutscene78 && flag != ConditionFlag.OccupiedInCutSceneEvent && Stage != Stage.Action && value && States.HasFlag(State.Navigating) && (flag == ConditionFlag.BetweenAreas || flag == ConditionFlag.BetweenAreas51 || flag == ConditionFlag.Jumping61))
+        if (Stage != Stage.Dead && Stage != Stage.Revived && !_recentlyWatchedCutscene && !Conditions.IsWatchingCutscene && flag != ConditionFlag.WatchingCutscene && flag != ConditionFlag.WatchingCutscene78 && flag != ConditionFlag.OccupiedInCutSceneEvent && Stage != Stage.Action && value && States.HasFlag(State.Navigating) && (flag == ConditionFlag.BetweenAreas || flag == ConditionFlag.BetweenAreas51 || flag == ConditionFlag.Jumping61))
         {
             Indexer++;
             Stage = Stage.Reading_Path;


### PR DESCRIPTION
hello, please review the following:

when reviving then taking shortcut, Condition_ConditionChange will cause Indexer++ skipping the actual step the player was on. 

~~the following adds a _recentlyRevived which is set in OnRevive and is removed after 14 seconds. the conditionChange during the shortcut transition ignores the transition~~
the following adds a Stage != Stage.Revived check to Condition_ConditionChange to prevent the Indexer increment*

issue was identified in Stone Vigil after dying to Boss 2. A death during Boss 1 did not cause the issue due to no shortcut being present upon revive