### PR TITLE
Fix RotationSolver disabling at final boss

### DIFF
--- a/AutoDuty/Managers/ActionsManager.cs
+++ b/AutoDuty/Managers/ActionsManager.cs
@@ -343,6 +343,8 @@ namespace AutoDuty.Managers
             _taskManager.Enqueue(() => BossMoveCheck(bossV3), "Boss-MoveCheck");
             if (AutoDuty.Plugin.BossObject == null)
                 _taskManager.Enqueue(() => (AutoDuty.Plugin.BossObject = ObjectHelper.GetBossObject()) != null, "Boss-GetBossObject");
+            if (AutoDuty.Plugin.Configuration.AutoManageRotationPluginState && !AutoDuty.Plugin.Configuration.UsingAlternativeRotationPlugin && ReflectionHelper.RotationSolver_Reflection.RotationSolverEnabled)
+                _taskManager.Enqueue(() => ReflectionHelper.RotationSolver_Reflection.RotationAuto(), "Boss-ReenableRotations");
             _taskManager.Enqueue(() => AutoDuty.Plugin.Action = $"Boss: {AutoDuty.Plugin.BossObject?.Name.TextValue ?? ""}", "Boss-SetActionVar");
             _taskManager.Enqueue(() => Svc.Condition[ConditionFlag.InCombat], "Boss-WaitInCombat");
             _taskManager.Enqueue(() => BossCheck(), int.MaxValue, "Boss-BossCheck");


### PR DESCRIPTION
When the setting "Disable automatically during cutscenes." is enabled in RotationSolver Reborn, RSR disables right before the final boss in dungeons, because there always is a small cutscene, even when you have "Skip cutscenes" enabled in the FFXIV settings.
Then I just stand there at the boss doing nothing and dying, which is quite annoying.
This should fix that by enabling RSR as soon as the "Boss" action starts.