### PR TITLE
Modified Rotation State Setting:

### DIFF
--- a/AutoDuty/Data/Enum.cs
+++ b/AutoDuty/Data/Enum.cs
@@ -101,5 +101,14 @@ namespace AutoDuty.Data
             Navigating = 2,
             Other = 4
         }
+
+        [Flags]
+        public enum SettingsActive : int
+        {
+            None = 0,
+            Vnav_Align_Camera_Off = 1,
+            Pandora_Interact_Objects = 2,
+            YesAlready = 4
+        }
     }
 }

--- a/AutoDuty/Helpers/AMHelper.cs
+++ b/AutoDuty/Helpers/AMHelper.cs
@@ -25,10 +25,10 @@ namespace AutoDuty.Helpers
                 Svc.Log.Info("AM Started");
                 AMRunning = true;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 SchedulerHelper.ScheduleAction("AMTimeOut", Stop, 600000);
                 Svc.Framework.Update += AMUpdate;
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -44,8 +44,6 @@ namespace AutoDuty.Helpers
             if (AM_IPCSubscriber.IsRunning())
                 AM_IPCSubscriber.Stop();
             _stop = true;
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool AMRunning = false;
@@ -62,6 +60,8 @@ namespace AutoDuty.Helpers
                     _stop = false;
                     AMRunning = false;
                     AutoDuty.Plugin.States &= ~State.Other;
+                    if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                        AutoDuty.Plugin.SetGeneralSettings(true);
                     Svc.Framework.Update -= AMUpdate;
                 }
                 else if (Svc.Targets.Target != null)

--- a/AutoDuty/Helpers/DesynthHelper.cs
+++ b/AutoDuty/Helpers/DesynthHelper.cs
@@ -18,11 +18,11 @@ namespace AutoDuty.Helpers
                 Svc.Log.Info("Desynth Started");
                 DesynthRunning = true;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 SchedulerHelper.ScheduleAction("DesynthTimeOut", Stop, 300000);
                 AutoDuty.Plugin.Action = "Desynthing";
                 Svc.Framework.Update += DesynthUpdate;
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -33,8 +33,6 @@ namespace AutoDuty.Helpers
             _stop = true;
             if (GenericHelpers.TryGetAddonByName("Desynth", out AtkUnitBase* addonDesynth))
                 addonDesynth->Close(true);
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool DesynthRunning = false;
@@ -61,6 +59,8 @@ namespace AutoDuty.Helpers
                     _stop = false;
                     DesynthRunning = false;
                     AutoDuty.Plugin.States &= ~State.Other;
+                    if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                        AutoDuty.Plugin.SetGeneralSettings(true);
                     Svc.Framework.Update -= DesynthUpdate;
                 }
                 return;

--- a/AutoDuty/Helpers/ExitDutyHelper.cs
+++ b/AutoDuty/Helpers/ExitDutyHelper.cs
@@ -16,13 +16,12 @@ namespace AutoDuty.Helpers
                 Svc.Log.Info("ExitDuty Started");
                 ExitDutyRunning = true;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 SchedulerHelper.ScheduleAction("ExitDutyTimeOut", Stop, 60000);
                 AutoDuty.Plugin.Action = "Exiting Duty";
                 _currentTerritoryType = Svc.ClientState.TerritoryType;
                 Svc.Framework.Update += ExitDutyUpdate;
-
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -34,9 +33,6 @@ namespace AutoDuty.Helpers
 
             if (GenericHelpers.TryGetAddonByName("ContentsFinderMenu", out AtkUnitBase* addonContentsFinderMenu))
                 addonContentsFinderMenu->Close(true);
-
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool ExitDutyRunning = false;
@@ -56,6 +52,8 @@ namespace AutoDuty.Helpers
                     _stop = false;
                     ExitDutyRunning = false;
                     AutoDuty.Plugin.States &= ~State.Other;
+                    if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                        AutoDuty.Plugin.SetGeneralSettings(true);
                     _currentTerritoryType = 0;
                     Svc.Framework.Update -= ExitDutyUpdate;
                 }

--- a/AutoDuty/Helpers/ExtractHelper.cs
+++ b/AutoDuty/Helpers/ExtractHelper.cs
@@ -26,8 +26,6 @@ namespace AutoDuty.Helpers
                     _stoppingCategory = 0;
                 AutoDuty.Plugin.Action = "Extracting Materia";
                 Svc.Framework.Update += ExtractUpdate;
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -35,15 +33,16 @@ namespace AutoDuty.Helpers
         {
             _currentCategory = 0;
             _switchedCategory = false;
+            AutoDuty.Plugin.States |= State.Other;
             AutoDuty.Plugin.Action = "";
+            if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                AutoDuty.Plugin.SetGeneralSettings(false);
             SchedulerHelper.DescheduleAction("ExtractTimeOut");
             _stop = true;
             if (GenericHelpers.TryGetAddonByName("MaterializeDialog", out AtkUnitBase* addonMaterializeDialog))
                 addonMaterializeDialog->Close(true);
             if (GenericHelpers.TryGetAddonByName("Materialize", out AtkUnitBase* addonMaterialize))
                 addonMaterialize->Close(true);
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool ExtractRunning = false;
@@ -73,6 +72,8 @@ namespace AutoDuty.Helpers
                     _stop = false;
                     ExtractRunning = false;
                     AutoDuty.Plugin.States &= ~State.Other;
+                    if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                        AutoDuty.Plugin.SetGeneralSettings(true);
                     Svc.Framework.Update -= ExtractUpdate;
                 }
                 return;

--- a/AutoDuty/Helpers/GCTurninHelper.cs
+++ b/AutoDuty/Helpers/GCTurninHelper.cs
@@ -23,10 +23,10 @@ namespace AutoDuty.Helpers
                 Svc.Log.Info("GCTurnin Started");
                 GCTurninRunning = true;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 SchedulerHelper.ScheduleAction("GCTurninTimeOut", Stop, 600000);
                 Svc.Framework.Update += GCTurninUpdate;
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -40,8 +40,6 @@ namespace AutoDuty.Helpers
             AutoDuty.Plugin.Action = "";
             SchedulerHelper.DescheduleAction("GCTurninTimeOut");
             _stop = true;
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool GCTurninRunning = false;
@@ -63,6 +61,8 @@ namespace AutoDuty.Helpers
                     _stop = false;
                     GCTurninRunning = false;
                     AutoDuty.Plugin.States &= ~State.Other;
+                    if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                        AutoDuty.Plugin.SetGeneralSettings(true);
                     Svc.Framework.Update -= GCTurninUpdate;
                 }
                 else if (Svc.Targets.Target != null)

--- a/AutoDuty/Helpers/GotoBarracksHelper.cs
+++ b/AutoDuty/Helpers/GotoBarracksHelper.cs
@@ -17,10 +17,10 @@ namespace AutoDuty.Helpers
                 Svc.Log.Info($"Goto Barracks Started");
                 GotoBarracksRunning = true;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 SchedulerHelper.ScheduleAction("GotoBarracksTimeOut", Stop, 600000);
                 Svc.Framework.Update += GotoBarracksUpdate;
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -33,11 +33,11 @@ namespace AutoDuty.Helpers
             GotoHelper.Stop();
             GotoBarracksRunning = false;
             AutoDuty.Plugin.States &= ~State.Other;
+            if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                AutoDuty.Plugin.SetGeneralSettings(true);
             if (GenericHelpers.TryGetAddonByName("SelectYesno", out AtkUnitBase* addonSelectYesno))
                 addonSelectYesno->Close(true);
             AutoDuty.Plugin.Action = "";
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool GotoBarracksRunning = false;

--- a/AutoDuty/Helpers/GotoHelper.cs
+++ b/AutoDuty/Helpers/GotoHelper.cs
@@ -34,6 +34,8 @@ namespace AutoDuty.Helpers
                 Svc.Log.Info($"Goto Started, Going to {territoryType}{(moveLocations.Count>0 ? $" and moving to {moveLocations[^1]} using {moveLocations.Count} pathLocations" : "")}");
                 GotoRunning = true;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 _territoryType = territoryType;
                 _gameObjectDataId = gameObjectDataId;
                 _moveLocations = moveLocations;
@@ -53,6 +55,8 @@ namespace AutoDuty.Helpers
             Svc.Framework.Update -= GotoUpdate;
             GotoRunning = false;
             AutoDuty.Plugin.States &= ~State.Other;
+            if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                AutoDuty.Plugin.SetGeneralSettings(true);
             _territoryType = 0;
             _gameObjectDataId = 0;
             _moveLocations = [];
@@ -67,8 +71,6 @@ namespace AutoDuty.Helpers
                 addonSelectYesno->Close(true);
             if (VNavmesh_IPCSubscriber.IsEnabled && VNavmesh_IPCSubscriber.Path_IsRunning())
                 VNavmesh_IPCSubscriber.Path_Stop();
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool GotoRunning = false;
@@ -143,8 +145,6 @@ namespace AutoDuty.Helpers
                         }
                         else
                         {
-                            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
                             if (TeleportHelper.MoveToClosestAetheryte())
                                 TeleportHelper.TeleportAethernet(aetheryte.AethernetName.Value?.Name ?? "", _territoryType);
                         }

--- a/AutoDuty/Helpers/GotoHousingHelper.cs
+++ b/AutoDuty/Helpers/GotoHousingHelper.cs
@@ -19,11 +19,11 @@ namespace AutoDuty.Helpers
                 Svc.Log.Info($"Goto {whichHousing} Started");
                 GotoHousingRunning = true;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 _whichHousing = whichHousing;
                 SchedulerHelper.ScheduleAction("GotoHousingTimeOut", Stop, 600000);
                 Svc.Framework.Update += GotoHousingUpdate;
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -36,8 +36,6 @@ namespace AutoDuty.Helpers
             _stop = true;
             _whichHousing = Housing.Apartment;
             AutoDuty.Plugin.Action = "";
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool InPrivateHouse(Housing whichHousing) =>
@@ -88,6 +86,8 @@ namespace AutoDuty.Helpers
                     _stop = false;
                     GotoHousingRunning = false;
                     AutoDuty.Plugin.States &= ~State.Other;
+                    if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                        AutoDuty.Plugin.SetGeneralSettings(true);
                     Svc.Framework.Update -= GotoHousingUpdate;
                 }
                 return;

--- a/AutoDuty/Helpers/GotoInnHelper.cs
+++ b/AutoDuty/Helpers/GotoInnHelper.cs
@@ -24,10 +24,10 @@ namespace AutoDuty.Helpers
                 GotoInnRunning = true;
                 _stop = false;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 SchedulerHelper.ScheduleAction("GotoInnTimeOut", Stop, 600000);
                 Svc.Framework.Update += GotoInnUpdate;
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -40,8 +40,6 @@ namespace AutoDuty.Helpers
             _stop = true;
             _whichGrandCompany = 0;
             AutoDuty.Plugin.Action = "";
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool GotoInnRunning = false;
@@ -63,6 +61,8 @@ namespace AutoDuty.Helpers
                     _stop = false;
                     GotoInnRunning = false;
                     AutoDuty.Plugin.States &= ~State.Other;
+                    if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                        AutoDuty.Plugin.SetGeneralSettings(true);
                     Svc.Framework.Update -= GotoInnUpdate;
                 }
                 else if (Svc.Targets.Target != null)

--- a/AutoDuty/Helpers/MapHelper.cs
+++ b/AutoDuty/Helpers/MapHelper.cs
@@ -92,6 +92,8 @@ namespace AutoDuty.Helpers
             Svc.Log.Info("Moving to Flag Marker");
             MoveToMapMarkerRunning = true;
             AutoDuty.Plugin.States |= State.Other;
+            if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                AutoDuty.Plugin.SetGeneralSettings(false);
             Svc.Framework.Update += MoveToMapMarkerUpdate;
         }
 
@@ -106,6 +108,8 @@ namespace AutoDuty.Helpers
             VNavmesh_IPCSubscriber.Path_Stop();
             MoveToMapMarkerRunning = false;
             AutoDuty.Plugin.States &= ~State.Other;
+            if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                AutoDuty.Plugin.SetGeneralSettings(true);
             flagMapMarker = null;
         }
 

--- a/AutoDuty/Helpers/ReflectionHelper.cs
+++ b/AutoDuty/Helpers/ReflectionHelper.cs
@@ -24,6 +24,13 @@ namespace AutoDuty.Helpers
                 if (DalamudReflector.TryGetDalamudPlugin("YesAlready", out var pl, false, true))
                     pl.GetFoP("Config").SetFoP("Enabled", trueFalse);
             }
+
+            internal static bool GetPluginEnabled()
+            {
+                if (DalamudReflector.TryGetDalamudPlugin("YesAlready", out var pl, false, true))
+                    return (bool)pl.GetFoP("Config").GetFoP("Enabled");
+                else return false;
+            }
         }
 
         internal static class RotationSolver_Reflection

--- a/AutoDuty/Helpers/RepairHelper.cs
+++ b/AutoDuty/Helpers/RepairHelper.cs
@@ -20,14 +20,14 @@ namespace AutoDuty.Helpers
                 Svc.Log.Info($"Repair Started");
                 RepairRunning = true;
                 AutoDuty.Plugin.States |= State.Other;
+                if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                    AutoDuty.Plugin.SetGeneralSettings(false);
                 _stop = false;
                 if (AutoDuty.Plugin.Configuration.AutoRepairSelf)
                     SchedulerHelper.ScheduleAction("RepairTimeOut", Stop, 300000);
                 else
                     SchedulerHelper.ScheduleAction("RepairTimeOut", Stop, 600000);
                 Svc.Framework.Update += RepairUpdate;
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
             }
         }
 
@@ -40,8 +40,6 @@ namespace AutoDuty.Helpers
             _seenAddon = false;
             AutoDuty.Plugin.Action = "";
             AgentModule.Instance()->GetAgentByInternalId(AgentId.Repair)->Hide();
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true);
         }
 
         internal static bool RepairRunning = false;
@@ -66,6 +64,8 @@ namespace AutoDuty.Helpers
                     _stop = false;
                     RepairRunning = false;
                     AutoDuty.Plugin.States &= ~State.Other;
+                    if (!AutoDuty.Plugin.States.HasFlag(State.Looping))
+                        AutoDuty.Plugin.SetGeneralSettings(true);
                     Svc.Framework.Update -= RepairUpdate;
                 }
                 else if (Svc.Targets.Target != null)

--- a/AutoDuty/Helpers/TeleportHelper.cs
+++ b/AutoDuty/Helpers/TeleportHelper.cs
@@ -78,8 +78,6 @@ namespace AutoDuty.Helpers
             if (aethernetName.IsNullOrEmpty() || !ObjectHelper.IsValid)
                 return true;
 
-            ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
-
             if (!GenericHelpers.TryGetAddonByName("TelepotTown", out AtkUnitBase* addon) || !GenericHelpers.IsAddonReady(addon))
             {
                 IGameObject? gameObject;

--- a/AutoDuty/IPC/IPCSubscriber.cs
+++ b/AutoDuty/IPC/IPCSubscriber.cs
@@ -161,6 +161,7 @@ namespace AutoDuty.IPC
 
         [EzIPC] internal static readonly Action<string, int> PauseFeature;
         [EzIPC] internal static readonly Action<string, bool> SetFeatureEnabled;
+        [EzIPC] internal static readonly Func<string, bool> GetFeatureEnabled;
         [EzIPC] internal static readonly Action<string, string, bool> SetConfigEnabled;
 
         internal static void Dispose() => IPCSubscriber_Common.DisposeAll(_disposalTokens);

--- a/AutoDuty/Managers/ActionsManager.cs
+++ b/AutoDuty/Managers/ActionsManager.cs
@@ -285,24 +285,9 @@ namespace AutoDuty.Managers
                     Interactable(gameObject);
                 }
             }, "Interactable-LoopCheck");
-            _taskManager.Enqueue(() =>
-            {
-                if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                    SchedulerHelper.ScheduleAction("InteractableEnableYesAlready",() => ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(true), 5000);
-                if (PandorasBox_IPCSubscriber.IsEnabled)
-                    SchedulerHelper.ScheduleAction("InteractableEnablePandora", () => PandorasBox_IPCSubscriber.SetFeatureEnabled("Auto-interact with Objects in Instances", true), 15000);
-            }, "Interactable-YesAlreadyPandoraSetEnableTrueAfter15s");
         }
         public unsafe void Interactable(string objectName)
         {
-            Svc.Log.Debug("Interactable-YesAlreadySetEnableFalse");
-            if (ReflectionHelper.YesAlready_Reflection.IsEnabled)
-                ReflectionHelper.YesAlready_Reflection.SetPluginEnabled(false);
-
-            Svc.Log.Debug("Interactable-PandoraSetEnableFalse");
-            if (PandorasBox_IPCSubscriber.IsEnabled)
-                PandorasBox_IPCSubscriber.SetFeatureEnabled("Auto-interact with Objects in Instances", false);
-
             IGameObject? gameObject = null;
 
             AutoDuty.Plugin.Action = $"Interactable: {objectName}";

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -28,7 +28,7 @@ namespace AutoDuty.Windows
         private static List<string> LevelingDuties = [
             "L15 (i0): Sastasha",
             "L16-L23 (i0): The TamTara Deepcroft",
-            "L24-31 (i0): The Thousanf Maws of TotoRak", 
+            "L24-31 (i0): The Thousand Maws of TotoRak", 
             "L32-40 (i0): Brayflox's Longstop",
             "L41-52 (i0): The Stone Vigil",
             "L53-60 (i105): Sohm Al",
@@ -37,7 +37,7 @@ namespace AutoDuty.Windows
             "L71-74 (i370): Holminster Switch",
             "L75-80 (i380): Qitana Ravel",
             "L81-86 (i500): The Tower of Zot",
-            "L87-90 (i515): Ktisis Hyporbea",
+            "L87-90 (i515): Ktisis Hyporboreia",
             "L91-100 (i630): Highest Level DT Dungeons"];
 
         internal static void Draw()

--- a/AutoDuty/Windows/Overlay.cs
+++ b/AutoDuty/Windows/Overlay.cs
@@ -53,7 +53,7 @@ public unsafe class Overlay : Window
             }
         }
 
-        if (Plugin.InDungeon || Plugin.States.HasFlag(State.Navigating))
+        if (Plugin.InDungeon || Plugin.States.HasFlag(State.Looping))
         {
             using (var d1 = ImRaii.Disabled(!Plugin.InDungeon || !ContentPathsManager.DictionaryPaths.ContainsKey(Svc.ClientState.TerritoryType) || Plugin.Stage > 0))
             {


### PR DESCRIPTION
- Rotation Solver Reborn will now check if in the State
- Before changing it. Readded Rotation State Setting to:
- Stage.Moving InCombat Detection
- Stage.Action Invoke AutoDuty will now check the states of:
Pandora - Auto-interact with Objects in Instances
YesAlready
and disable both on start of loops, and other actions and reenable if applicable at the end of loops or stop Fixed a bug that was not showing Overlay at times.