### PR TITLE
Fix RSR reenabling during cutscenes

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -1238,7 +1238,7 @@ public sealed class AutoDuty : IDalamudPlugin
                 if (Indexer == -1 || Indexer >= ListBoxPOSText.Count)
                     return;
 
-                if (Configuration.AutoManageRotationPluginState && !Configuration.UsingAlternativeRotationPlugin)
+                if (Configuration.AutoManageRotationPluginState && !Configuration.UsingAlternativeRotationPlugin && !Svc.Condition[ConditionFlag.OccupiedInCutSceneEvent])
                     SetRotationPluginSettings(true);
 
                 if (!TaskManager.IsBusy)


### PR DESCRIPTION
After defeating the final boss and having "Disable automatically during cutscenes." enabled in RSR, you'll get spammed with RSR enabling and disabling:
![Screenshot 2024-08-24 172701](https://github.com/user-attachments/assets/28e558e7-8cc7-4118-8fb4-efe4b4f29994)
This happens because AutoDuty keeps trying to enable RSR and RSR keeps trying to disable during a cutscene.
The fix is using the same condition that [RSR uses to disable itself](https://github.com/FFXIV-CombatReborn/RotationSolverReborn/blob/2e1ccb9456f5242548e1b99a2361809d10ede064/RotationSolver/Commands/RSCommands_Actions.cs#L168).