### PR TITLE
Added command at the start and at the completion of a loop

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -619,16 +619,16 @@ public sealed class AutoDuty : IDalamudPlugin
                 TaskManager.Enqueue(() => CurrentLoop = 0);
                 TaskManager.Enqueue(() => Stage = Stage.Stopped);
             }
-        else if (Configuration.TerminationMethodEnum == TerminationMode.Custom)
-        {
-            Configuration.TerminationCustomCommand
-                .Split("\n")
-                .Where(c => c.StartsWith('/'))
-                .Each(c => TaskManager.Enqueue(() => Chat.ExecuteCommand(c), "Run-ExecuteCommands"));
-            TaskManager.Enqueue(() => States &= ~PluginState.Looping);
-            TaskManager.Enqueue(() => CurrentLoop = 0);
-            TaskManager.Enqueue(() => Stage = Stage.Stopped);
-        }
+            else if (Configuration.TerminationMethodEnum == TerminationMode.Custom)
+            {
+                Configuration.TerminationCustomCommand
+                    .Split("\n")
+                    .Where(c => c.StartsWith('/'))
+                    .Each(c => TaskManager.Enqueue(() => Chat.ExecuteCommand(c), "Run-ExecuteCommands"));
+                TaskManager.Enqueue(() => States &= ~PluginState.Looping);
+                TaskManager.Enqueue(() => CurrentLoop = 0);
+                TaskManager.Enqueue(() => Stage = Stage.Stopped);
+            }
         }
 
         States &= ~PluginState.Looping;
@@ -689,20 +689,21 @@ public sealed class AutoDuty : IDalamudPlugin
                     }
                 }
     
-            if (Configuration.AutoRepair && InventoryHelper.CanRepair())
+                if (Configuration.AutoRepair && InventoryHelper.CanRepair())
                 {
                     TaskManager.Enqueue(() => RepairHelper.Invoke(), "Run-AutoRepair");
                     TaskManager.DelayNext("Run-AutoRepairDelay50", 50);
                     TaskManager.Enqueue(() => RepairHelper.State != ActionState.Running, int.MaxValue, "Run-WaitAutoRepairComplete");
                     TaskManager.Enqueue(() => !ObjectHelper.IsOccupied, "Run-WaitAutoRepairNotIsOccupied");
                 }
-    
-            if (Configuration.ShouldExecuteCommand)
-                Configuration.ExecuteCommand
-                    .Split("\n")
-                    .Where(c => c.StartsWith('/'))
-                    .Each(c=> TaskManager.Enqueue(() => Chat.ExecuteCommand(c), "Run-ExecuteCommands"));
-            if (!Configuration.Squadron && Configuration.RetireMode)
+        
+                if (Configuration.ShouldExecuteCommand)
+                    Configuration.ExecuteCommand
+                        .Split("\n")
+                        .Where(c => c.StartsWith('/'))
+                        .Each(c=> TaskManager.Enqueue(() => Chat.ExecuteCommand(c), "Run-ExecuteCommands"));
+                        
+                if (!Configuration.Squadron && Configuration.RetireMode)
                 {
                     if (Configuration.RetireLocationEnum == RetireLocation.GC_Barracks)
                         TaskManager.Enqueue(() => GotoBarracksHelper.Invoke(), "Run-GotoBarracksInvoke");

--- a/AutoDuty/Data/Enum.cs
+++ b/AutoDuty/Data/Enum.cs
@@ -33,7 +33,8 @@ namespace AutoDuty.Data
             Logout = 1,
             Start_AR_Multi_Mode = 2,
             Kill_Client = 3,
-            Kill_PC = 4
+            Kill_PC = 4,
+            Custom = 5,
         }
         public enum Role : int
         {

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -317,6 +317,9 @@ public class Configuration : IPluginConfiguration
     public bool StopItemQty = false;
     public Dictionary<uint, KeyValuePair<string, int>> StopItemQtyItemDictionary = [];
     public int StopItemQtyInt = 1;
+    public TerminationMode StartingTerminationMethodEnum = TerminationMode.Do_Nothing;
+    public bool ShouldExecuteCommand;
+    public string ExecuteCommand = "";
     public bool PlayEndSound = false;
     public bool CustomSound = false;
     public float CustomSoundVolume = 0.5f;
@@ -324,6 +327,7 @@ public class Configuration : IPluginConfiguration
     public string SoundPath = "";
     public TerminationMode TerminationMethodEnum = TerminationMode.Do_Nothing;
     public bool TerminationKeepActive = true;
+    public string TerminationCustomCommand = "";
 
     //BMAI Config Options
     public bool HideBossModAIConfig = false;
@@ -1279,6 +1283,20 @@ public static class ConfigTab
                 }
                 ImGui.EndListBox();
             }
+            
+            if (ImGui.Checkbox("Execute Commands on Starting of All Loops ", ref Configuration.ShouldExecuteCommand))
+                Configuration.Save();
+            
+            ImGuiComponents.HelpMarker("Execute commands at the start of all loops.\nFor example, /echo test");
+            
+            if (Configuration.ShouldExecuteCommand)
+            {
+                ImGui.Indent();
+                if (ImGuiEx.InputTextMultilineExpanding("##ExecuteCommand", ref Configuration.ExecuteCommand))
+                    Configuration.Save();
+                ImGui.Unindent();
+            }
+            
             if (ImGui.Checkbox("Play Sound on Completion of All Loops: ", ref Configuration.PlayEndSound)) //Heavily Inspired by ChatAlerts
                 Configuration.Save();
             if (Configuration.PlayEndSound)
@@ -1310,6 +1328,16 @@ public static class ConfigTab
             {
                 ImGui.Indent();
                 if (ImGui.Checkbox("Keep Termination option after execution ", ref Configuration.TerminationKeepActive))
+                    Configuration.Save();
+                ImGui.Unindent();
+            }
+
+            if (Configuration.TerminationMethodEnum is TerminationMode.Custom)
+            {
+                ImGui.Indent();
+                ImGui.Text("Custom Command: ");
+                ImGuiComponents.HelpMarker("Execute commands at the completion of all loops.\nFor example, /echo test");
+                if (ImGuiEx.InputTextMultilineExpanding("##CustomCommand", ref Configuration.TerminationCustomCommand))
                     Configuration.Save();
                 ImGui.Unindent();
             }

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -1328,21 +1328,21 @@ public static class ConfigTab
                     ImGui.EndListBox();
                 }
                 
-            if (ImGui.Checkbox("Execute Commands on Starting of All Loops ", ref Configuration.ShouldExecuteCommand))
-                Configuration.Save();
-            
-            ImGuiComponents.HelpMarker("Execute commands at the start of all loops.\nFor example, /echo test");
-            
-            if (Configuration.ShouldExecuteCommand)
-            {
-                ImGui.Indent();
-                if (ImGuiEx.InputTextMultilineExpanding("##ExecuteCommand", ref Configuration.ExecuteCommand))
+                if (ImGui.Checkbox("Execute Commands on Starting of All Loops ", ref Configuration.ShouldExecuteCommand))
                     Configuration.Save();
-                ImGui.Unindent();
-            }
-            
-            if (ImGui.Checkbox("Play Sound on Completion of All Loops: ", ref Configuration.PlayEndSound)) //Heavily Inspired by ChatAlerts
-                    Configuration.Save();
+                
+                ImGuiComponents.HelpMarker("Execute commands at the start of all loops.\nFor example, /echo test");
+                
+                if (Configuration.ShouldExecuteCommand)
+                {
+                    ImGui.Indent();
+                    if (ImGuiEx.InputTextMultilineExpanding("##ExecuteCommand", ref Configuration.ExecuteCommand))
+                        Configuration.Save();
+                    ImGui.Unindent();
+                }
+                
+                if (ImGui.Checkbox("Play Sound on Completion of All Loops: ", ref Configuration.PlayEndSound)) //Heavily Inspired by ChatAlerts
+                        Configuration.Save();
                 if (Configuration.PlayEndSound)
                 {
                     if (ImGuiEx.IconButton(FontAwesomeIcon.Play, "##ConfigSoundTest", new Vector2(ImGui.GetItemRectSize().Y)))


### PR DESCRIPTION
There was a request in the Jp community to cut off other plugins to start the loop. For example, those that log Splatoon, ARR, Lemegeton, etc. To turn these off all at once, before and after the start and after the completion of all loops, would be a great feature. It would be useful to be able to type a command (macro?) starting and completion of all loops to turn them off all at once.

Changes
- Added command at the start and at the completion of a loop
- Added command settings to config

(Translated by DeepL)
