### PR TITLE
Trust updates

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -362,7 +362,7 @@ public sealed class AutoDuty : IDalamudPlugin
                 TaskManager.DelayNext("Loop-WaitTimeBeforeAfterLoopActions", Configuration.WaitTimeBeforeAfterLoopActions * 1000);
                 TaskManager.Enqueue(() => { Action = $"After Loop Actions"; }, "Loop-AfterLoopActionsSetAction");
                 
-                if (TrustLevelingEnabled)
+                if (TrustLevelingEnabled && TrustManager.members.Any(tm => tm.Value.Level < tm.Value.LevelCap))
                 {
                     TrustManager.ClearCachedLevels(CurrentTerritoryContent);
                     TrustManager.GetLevels(CurrentTerritoryContent);

--- a/AutoDuty/Helpers/ImGuiHelper.cs
+++ b/AutoDuty/Helpers/ImGuiHelper.cs
@@ -12,6 +12,9 @@ namespace AutoDuty.Helpers
         public static readonly Vector4 VersionColor = new(0, 1, 1, 1);
         public static readonly Vector4 LinkColor = new(0, 200, 238, 1);
 
+        public static readonly Vector4 White = new(1, 1, 1, 1);
+        public static readonly Vector4 MaxLevelColor = new(0.5f, 1, 0.5f, 1);
+
         public static readonly Vector4 RoleTankColor       = new(0, 0.5f, 1, 1);
         public static readonly Vector4 RoleHealerColor     = new(0, 1, 0, 1);
         public static readonly Vector4 RoleDPSColor        = new(1, 0, 0, 1);

--- a/AutoDuty/Helpers/LevelingHelper.cs
+++ b/AutoDuty/Helpers/LevelingHelper.cs
@@ -45,13 +45,13 @@ namespace AutoDuty.Helpers
             CombatRole combatRole = Player.Object.GetRole();
             if (trust)
             {
-                if (TrustManager.members.All(tm => tm.Value.Level <= 0)) 
+                if (TrustManager.members.All(tm => !tm.Value.LevelIsSet)) 
                     return null;
 
                 TrustMember?[] memberTest = new TrustMember?[3];
 
                 foreach ((TrustMemberName _, TrustMember member) in TrustManager.members)
-                    if (member.Level < lvl && member.Level < member.LevelCap && member.Level > 0 && memberTest.CanSelectMember(member, combatRole))
+                    if (member.Level < lvl && member.Level < member.LevelCap && member.LevelIsSet && memberTest.CanSelectMember(member, combatRole))
                         lvl = (short) member.Level;
             }
 

--- a/AutoDuty/Helpers/ObjectHelper.cs
+++ b/AutoDuty/Helpers/ObjectHelper.cs
@@ -206,7 +206,6 @@ namespace AutoDuty.Helpers
             Ninja = 30,
             Machinist = 31,
             DarkKnight = 32,
-            Astralogian = 33,
             Astrologian = 33,
             Samurai = 34,
             RedMage = 35,
@@ -215,6 +214,7 @@ namespace AutoDuty.Helpers
             Dancer = 38,
             Reaper = 39,
             Sage = 40,
+            Pictomancer = 42
         }
 
         internal static unsafe bool IsValid => Svc.Condition.Any()

--- a/AutoDuty/Helpers/TrustHelper.cs
+++ b/AutoDuty/Helpers/TrustHelper.cs
@@ -40,11 +40,8 @@ namespace AutoDuty.Helpers
 
         private static bool CanTrustRunMembers(Content content)
         {
-            if (content.TrustMembers.Any(tm => tm.Level <= 0))
-            {
+            if (content.TrustMembers.Any(tm => !tm.LevelIsSet)) 
                 AutoDuty.Plugin.TrustManager.GetLevels(content);
-                return false;
-            }
 
             TrustMember?[] members = new TrustMember?[3];
 

--- a/AutoDuty/Managers/TrustMember.cs
+++ b/AutoDuty/Managers/TrustMember.cs
@@ -12,8 +12,25 @@
         public string                                Name       { get; set; }
         public TrustMemberName                       MemberName { get; set; }
 
-        public uint Level    { get; set; }
-        public uint LevelCap { get; set; }
+        public uint Level     { get; set; }
+        public uint LevelCap  { get; set; }
+        public uint LevelInit { get; set; }
+        public bool LevelIsSet  { get; set; }
+
+        public void ResetLevel()
+        {
+            this.LevelIsSet = false;
+            this.Level      = this.LevelInit;
+        }
+
+        public void SetLevel(uint level)
+        {
+            if (level >= this.LevelInit)
+            {
+                this.LevelIsSet = true;
+                this.Level      = level;
+            }
+        }
     }
 
     public enum TrustMemberName : byte

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -456,7 +456,7 @@ namespace AutoDuty.Windows
                                         if (member.Level > 0)
                                         {
                                             ImGui.SameLine(0, 2);
-                                            ImGuiEx.TextV($"{member.Level.ToString().ReplaceByChar(Digits.Normal, Digits.GameFont)}");
+                                            ImGuiEx.TextV(member.Level < member.LevelCap ? ImGuiHelper.White : ImGuiHelper.MaxLevelColor, $"{member.Level.ToString().ReplaceByChar(Digits.Normal, Digits.GameFont)}");
                                         }
 
                                         ImGui.NextColumn();

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -403,7 +403,7 @@ namespace AutoDuty.Windows
                                     }
                                 }
 
-                                using (ImRaii.Disabled(Plugin.TrustLevelingEnabled))
+                                using (ImRaii.Disabled(Plugin.TrustLevelingEnabled && TrustManager.members.Any(tm => tm.Value.Level < tm.Value.LevelCap)))
                                 {
                                     foreach (TrustMember member in _dutySelected.Content.TrustMembers)
                                     {


### PR DESCRIPTION
- Trust members are initialized with their starting level.
- Trust member level is displayed as greenish if they are at cap
- Trust member selection is not locked during leveling, if all members are at cap.