### PR TITLE
Update GitHub action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,5 +41,6 @@ jobs:
           path: "AutoDuty/bin/Release/AutoDuty/latest.zip"
           type: "latest"
           dalamud_version: "10"
+          changelog: ${{ github.event.release.body }}
         env:
           PUBLISHER_KEY: ${{ secrets.PUBLISHER_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Get Tag Name
-        run: echo "tag=$(echo ${{ github.ref }} | sed 's/refs\/tags\/v//')" >> $GITHUB_ENV
-
       - name: Set up .NET
         uses: actions/setup-dotnet@v3
         with:
@@ -32,7 +29,7 @@ jobs:
         run: dotnet restore
 
       - name: Build Project
-        run: dotnet build --configuration Release AutoDuty/AutoDuty.csproj -p:AssemblyVersion=${{ env.tag }}
+        run: dotnet build --configuration Release AutoDuty/AutoDuty.csproj -p:AssemblyVersion=${{ github.ref_name }}
 
       - name: Publish Version
         uses: PunishXIV/dynamis-action@v1
@@ -40,7 +37,7 @@ jobs:
         with:
           plugin_id: 54
           internal_name: "AutoDuty"
-          version_number: ${{ env.tag }}
+          version_number: ${{ github.ref_name }}
           path: "AutoDuty/bin/Release/AutoDuty/latest.zip"
           type: "latest"
           dalamud_version: "10"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,10 +43,3 @@ jobs:
           dalamud_version: "10"
         env:
           PUBLISHER_KEY: ${{ secrets.PUBLISHER_KEY }}
-
-      - name: Echo Environment Variables
-        run: |
-          echo "github.ref ${{ github.ref }}"
-          echo "github.ref_name ${{ github.ref_name }}"
-          echo "github.event.release.name ${{ github.event.release.name }}"
-          echo "github.event.release.body ${{ github.event.release.body }}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,14 @@
 name: Build & Publish to Dynamis
 
 on:
-  push:
-    tags:
-      - "v*.*.*.*"
+  release:
+    types: [published]
 
 jobs:
   Build:
     runs-on: ubuntu-latest
     env:
-        DALAMUD_HOME: /tmp/dalamud
+      DALAMUD_HOME: /tmp/dalamud
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -23,7 +22,7 @@ jobs:
         uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 8.0.x
-          
+
       - name: Download Dalamud Latest
         run: |
           wget https://goatcorp.github.io/dalamud-distrib/latest.zip -O ${{ env.DALAMUD_HOME }}.zip


### PR DESCRIPTION
- Uses the "on release" action trigger instead of checking for new tags
- Removes the step to get current tag since that's available as `github.ref_name` already
- Removed extra echos and last step entirely
- Added pushing the release body to changelog for plugin

Ignore the double commits, I had to rebase to get my commit signing to work since it somehow broke between yesterday and today.