### PR TITLE
Fixed issues in Leveling Mode

### DIFF
--- a/AutoDuty/AutoDuty.cs
+++ b/AutoDuty/AutoDuty.cs
@@ -52,7 +52,17 @@ public sealed class AutoDuty : IDalamudPlugin
     [PluginService] internal static IDalamudPluginInterface PluginInterface { get; private set; } = null!;
     internal List<string> ListBoxPOSText { get; set; } = [];
     internal int CurrentLoop = 0;
-    internal Content? CurrentTerritoryContent = null;
+    internal KeyValuePair<ushort, Job?> CurrentPlayerItemLevelandClassJob = new(0, null); 
+    private Content? currentTerritoryContent = null;
+    internal Content? CurrentTerritoryContent
+    {
+        get => currentTerritoryContent;
+        set
+        {
+            CurrentPlayerItemLevelandClassJob = new(InventoryHelper.CurrentItemLevel, Player.Job);
+            currentTerritoryContent = value;
+        }
+    }
     internal uint CurrentTerritoryType = 0;
     internal int CurrentPath = -1;
 
@@ -106,6 +116,7 @@ public sealed class AutoDuty : IDalamudPlugin
         {
             if (value != LevelingMode.None)
             {
+                Svc.Log.Debug($"Setting Leveling mode to {value}");
                 Content? duty = LevelingHelper.SelectHighestLevelingRelevantDuty(value == LevelingMode.Trust);
 
                 if (duty != null)
@@ -114,6 +125,7 @@ public sealed class AutoDuty : IDalamudPlugin
                     MainTab.DutySelected = ContentPathsManager.DictionaryPaths[duty.TerritoryType];
                     CurrentTerritoryContent = duty;
                     MainTab.DutySelected.SelectPath(out CurrentPath);
+                    Svc.Log.Debug($"Leveling Mode: Setting duty to {duty.Name}");
                 }
                 else
                 {
@@ -121,6 +133,7 @@ public sealed class AutoDuty : IDalamudPlugin
                     MainListClicked = false;
                     CurrentTerritoryContent = null;
                     levelingModeEnum = LevelingMode.None;
+                    Svc.Log.Debug($"Leveling Mode: No appropriate leveling duty found");
                 }
             }
             else

--- a/AutoDuty/Data/Classes.cs
+++ b/AutoDuty/Data/Classes.cs
@@ -31,7 +31,7 @@ namespace AutoDuty.Data
             public int VVDIndex { get; set; } = -1;
             public bool GCArmyContent { get; set; } = false;
             public int GCArmyIndex { get; set; } = -1;
-            public List<TrustMember> TrustMembers { get; set; } = new();
+            public List<TrustMember> TrustMembers { get; set; } = [];
         }
 
         public class TrustMember

--- a/AutoDuty/Helpers/PlayerHelper.cs
+++ b/AutoDuty/Helpers/PlayerHelper.cs
@@ -1,7 +1,6 @@
 ﻿using ECommons.DalamudServices;
 using ECommons.ExcelServices;
 using ECommons.GameFunctions;
-using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using Lumina.Excel.GeneratedSheets;
 using FFXIVClientStructs.FFXIV.Client.Game.UI;
 using System.Linq;
@@ -20,7 +19,7 @@ namespace AutoDuty.Helpers
             return playerState->ClassJobLevels[Svc.Data.GetExcelSheet<ClassJob>()?.GetRow((uint) (job ?? (Player.Available ? Player.Object.GetJob() : AutoDuty.Plugin.JobLastKnown)))?.ExpArrayIndex ?? 0];
         }
 
-        internal static unsafe short GetCurrentItemLevelFromGearSet(int gearsetId = -1, bool updateGearsetBeforeCheck = true)
+        /*internal static unsafe short GetCurrentItemLevelFromGearSet(int gearsetId = -1, bool updateGearsetBeforeCheck = true)
         {
             RaptureGearsetModule* gearsetModule = RaptureGearsetModule.Instance();
             if (gearsetId < 0)
@@ -28,7 +27,7 @@ namespace AutoDuty.Helpers
             if (updateGearsetBeforeCheck)
                 gearsetModule->UpdateGearset(gearsetId);
             return gearsetModule->GetGearset(gearsetId)->ItemLevel;
-        }
+        }*/
 
         internal static CombatRole GetRole(this Job? job) => 
             job != null ? GetRole((Job)job) : CombatRole.NonCombat;

--- a/AutoDuty/Helpers/TrustHelper.cs
+++ b/AutoDuty/Helpers/TrustHelper.cs
@@ -78,9 +78,9 @@ namespace AutoDuty.Helpers
 
             try
             {
-                TrustMember[] membersPossible = content.TrustMembers
+                TrustMember[] membersPossible = [.. content.TrustMembers
                                                        .OrderBy(tm => tm.Level + (tm.Level < tm.LevelCap ? 0 : 100) + 
-                                                                      (playerRole == CombatRole.DPS ? playerJobRole == tm.Job.GetJobRole() ? 0.5f : 0 : 0)).ToArray();
+                                                                      (playerRole == CombatRole.DPS ? playerJobRole == tm.Job!.GetJobRole() ? 0.5f : 0 : 0))];
                 foreach (TrustMember member in membersPossible)
                 {
                     Svc.Log.Info("checking: " + member.Name);
@@ -196,18 +196,27 @@ namespace AutoDuty.Helpers
             _getLevelsContent = content;
 
             _getLevelsContent ??= AutoDuty.Plugin.CurrentTerritoryContent;
-            
-            if (_getLevelsContent == null) return;
 
-            if (_getLevelsContent.DawnIndex < 1)
+            if (_getLevelsContent == null)
+            {
+                Svc.Log.Debug($"Get Trust Levels: our content was null, returning");
                 return;
-
+            }
+            if (_getLevelsContent.DawnIndex < 0)
+            {
+                Svc.Log.Debug($"Get Trust Levels: our content was not dawn content, returning");
+                return;
+            }
             if (_getLevelsContent.TrustMembers.TrueForAll(tm => tm.LevelIsSet))
+            {
+                Svc.Log.Debug($"Get Trust Levels: we already have all our trust levels, returning");
                 return;
-
+            }
             if (!_getLevelsContent.CanTrustRun(false))
+            {
+                Svc.Log.Debug($"Get Trust Levels: this content CanTrustRun is false, returning");
                 return;
-
+            }
             Svc.Log.Info($"TrustHelper - Getting trust levels for expansion {_getLevelsContent.ExVersion}");
 
             State = ActionState.Running;


### PR DESCRIPTION
Fixed an issue where Leveling Mode would not Check Trust member levels when you only have the 1st Dungeon in any xpac unlocked
Trust Leveling Mode will now turn off on Class Change 
Trust Leveling Mode will now turn off if your iLevel becomes lower than 370 
Support Leveling Mode will now Rechoose the Duty on iLevel Change 
Added a TON of Debug logging to Leveling Mode