### PR TITLE
Fixes

### DIFF
--- a/AutoDuty/Helpers/AutoRetainerHelper.cs
+++ b/AutoDuty/Helpers/AutoRetainerHelper.cs
@@ -50,16 +50,9 @@ namespace AutoDuty.Helpers
         private static bool _autoRetainerStarted = false;
         private static IGameObject? SummoningBellGameObject => Svc.Objects.FirstOrDefault(x => x.DataId == SummoningBellHelper.SummoningBellDataIds((uint)AutoDuty.Plugin.Configuration.PreferredSummoningBellEnum));
 
-        internal static unsafe void AutoRetainerStopUpdate(IFramework framework)
+        internal static unsafe void CloseRetainerWindows()
         {
-
-            if (!Svc.Condition[ConditionFlag.OccupiedSummoningBell])
-            {
-                State = ActionState.None;
-                AutoDuty.Plugin.States &= ~PluginState.Other;
-                Svc.Framework.Update -= AutoRetainerStopUpdate;
-            }
-            else if (Svc.Targets.Target != null)
+            if (Svc.Targets.Target != null)
                 Svc.Targets.Target = null;
             else if (GenericHelpers.TryGetAddonByName("SelectYesno", out AtkUnitBase* addonSelectYesno))
                 addonSelectYesno->Close(true);
@@ -69,6 +62,19 @@ namespace AutoDuty.Helpers
                 addonRetainerList->Close(true);
             else if (GenericHelpers.TryGetAddonByName("RetainerTaskAsk", out AtkUnitBase* addonRetainerSell))
                 addonRetainerSell->Close(true);
+        }
+
+        internal static unsafe void AutoRetainerStopUpdate(IFramework framework)
+        {
+
+            if (!Svc.Condition[ConditionFlag.OccupiedSummoningBell])
+            {
+                State = ActionState.None;
+                AutoDuty.Plugin.States &= ~PluginState.Other;
+                Svc.Framework.Update -= AutoRetainerStopUpdate;
+            }
+            else
+                CloseRetainerWindows();
         }
 
         internal static unsafe void AutoRetainerUpdate(IFramework framework)

--- a/AutoDuty/Helpers/GCTurninHelper.cs
+++ b/AutoDuty/Helpers/GCTurninHelper.cs
@@ -38,9 +38,9 @@ namespace AutoDuty.Helpers
             _deliverooStarted = false;
             GotoHelper.Stop();
             AutoDuty.Plugin.Action = "";
-            SchedulerHelper.DescheduleAction("GCTurninTimeOut");
             Svc.Framework.Update += GCTurninStopUpdate;
             Svc.Framework.Update -= GCTurninUpdate;
+            SchedulerHelper.DescheduleAction("GCTurninTimeOut");
         }
 
         internal static ActionState State = ActionState.None;

--- a/AutoDuty/Helpers/InventoryHelper.cs
+++ b/AutoDuty/Helpers/InventoryHelper.cs
@@ -58,6 +58,8 @@ namespace AutoDuty.Helpers
             }
         }
 
+        internal static bool IsItemAvailable(uint itemId, bool allowHq = true) => (allowHq && ItemCount(itemId + 1_000_000) >= 1) || ItemCount(itemId) >= 1;
+
         internal static void EquipGear(InventoryType type, int slotIndex, bool? ring = null)
         {
             InventoryItem* item = InventoryManager.Instance()->GetInventorySlot(type, slotIndex);

--- a/AutoDuty/Helpers/TrustHelper.cs
+++ b/AutoDuty/Helpers/TrustHelper.cs
@@ -187,7 +187,7 @@ namespace AutoDuty.Helpers
 
         internal static void ClearCachedLevels() => Members.Each(x => x.Value.ResetLevel());
 
-        internal static void ClearCachedLevels(Content content) => content.TrustMembers.Each(x => x.ResetLevel());
+        internal static void ClearCachedLevels(Content content) => content?.TrustMembers.Each(x => x.ResetLevel());
 
         internal static void GetLevels(Content? content)
         {
@@ -220,8 +220,8 @@ namespace AutoDuty.Helpers
             Svc.Log.Info($"TrustHelper - Getting trust levels for expansion {_getLevelsContent.ExVersion}");
 
             State = ActionState.Running;
-            
             Svc.Framework.Update += GetLevelsUpdate;
+            SchedulerHelper.ScheduleAction("CheckTrustLevelTimeout", Stop, 2500);
         }
 
         private unsafe static void Stop()
@@ -232,6 +232,7 @@ namespace AutoDuty.Helpers
             State = ActionState.None; 
             Svc.Log.Info($"TrustHelper - Done getting trust levels for expansion {_getLevelsContent?.ExVersion}");
             _getLevelsContent = null;
+            SchedulerHelper.DescheduleAction("CheckTrustLevelTimeout");
         }
 
         internal static ActionState State = ActionState.None;

--- a/AutoDuty/Managers/ActionsManager.cs
+++ b/AutoDuty/Managers/ActionsManager.cs
@@ -440,19 +440,19 @@ namespace AutoDuty.Managers
         {
             if (gameObjects == null || gameObjects.Count < 1)
             {
-                _taskManager.DelayNext("Boss-WaitASecToLootChest", 1000);
+                _taskManager.DelayNext("BossLoot-WaitASecToLootChest", 1000);
                 return;
             }
 
-            _taskManager.Enqueue(() => MovementHelper.Move(gameObjects[index], 0.25f, 1f));
+            _taskManager.Enqueue(() => MovementHelper.Move(gameObjects[index], 0.25f, 1f), "BossLoot-MoveToChest");
             _taskManager.Enqueue(() =>
             {
                 index++;
                 if (gameObjects.Count > index)
                     BossLoot(gameObjects, index);
                 else
-                    _taskManager.DelayNext("Boss-WaitASecToLootChest", 1000);
-            });
+                    _taskManager.DelayNext("BossLoot-WaitASecToLootChest", 1000);
+            }, "BossLoot-LoopOrDelay");
         }
 
         public void Boss(Vector3 bossV3)


### PR DESCRIPTION
Added Check for OccupiedBySummoningBell when Running
- If AutoRetainer is not Running or Not IsBusy 
-- Will Close all RetainerWindows and detarget summoning bell 
Fixed a bug in MainTab that was checking Player Level and iLevel, then resetting content, when player was not Ready 
Added null check to ClearLevelCache
Added IsItemAvailable Checks to AutoConsume
Added AutoEquipRecommendedgear to PreLoop if not in Leveling Mode
Fixed UnsyncTag