### PR TITLE
Fixed a bug that would let you *TRY* (and sometimes crash) entering an incompatible TT for DutyMode in /ad run command

### DIFF
--- a/AutoDuty/Data/Classes.cs
+++ b/AutoDuty/Data/Classes.cs
@@ -20,18 +20,17 @@ namespace AutoDuty.Data
             public uint ExVersion { get; set; }
             public byte ClassJobLevelRequired { get; set; }
             public uint ItemLevelRequired { get; set; }
-            public bool DawnContent { get; set; } = false;
             public int DawnIndex { get; set; } = -1;
             public uint ContentFinderCondition { get; set; }
             public uint ContentType { get; set; }
             public uint ContentMemberType { get; set; }
-            public bool TrustContent { get; set; } = false;
             public int TrustIndex { get; set; } = -1;
             public bool VariantContent { get; set; } = false;
             public int VVDIndex { get; set; } = -1;
             public bool GCArmyContent { get; set; } = false;
             public int GCArmyIndex { get; set; } = -1;
             public List<TrustMember> TrustMembers { get; set; } = [];
+            public DutyMode DutyModes { get; set; } = DutyMode.None;
         }
 
         public class TrustMember

--- a/AutoDuty/Data/Enums.cs
+++ b/AutoDuty/Data/Enums.cs
@@ -100,16 +100,17 @@ namespace AutoDuty.Data
             Running = 1
         }
 
+        [Flags]
         public enum DutyMode : int
         {
             None = 0,
             Support = 1,
             Trust = 2,
-            Squadron = 3,
-            Regular = 4,
-            Trial = 5,
-            Raid = 6,
-            Variant = 7
+            Squadron = 4,
+            Regular = 8,
+            Trial = 16,
+            Raid = 32,
+            Variant = 64
         }
 
         public enum LevelingMode : int

--- a/AutoDuty/Helpers/TrustHelper.cs
+++ b/AutoDuty/Helpers/TrustHelper.cs
@@ -30,7 +30,7 @@ namespace AutoDuty.Helpers
 
         internal static bool CanTrustRun(this Content content, bool checkTrustLevels = true)
         {
-            if (!content.TrustContent)
+            if (!content.DutyModes.HasFlag(DutyMode.Trust))
                 return false;
             
             if (!UIState.IsInstanceContentCompleted(content.Id))

--- a/AutoDuty/Windows/MainTab.cs
+++ b/AutoDuty/Windows/MainTab.cs
@@ -340,7 +340,7 @@ namespace AutoDuty.Windows
                                 if (ImGui.Button("Refresh", new Vector2(ImGui.GetContentRegionAvail().X, 0)))
                                 {
                                     if (InventoryHelper.CurrentItemLevel < 370)
-                                        AutoDuty.Plugin.LevelingModeEnum = LevelingMode.None;
+                                        Plugin.LevelingModeEnum = LevelingMode.None;
                                     TrustHelper.ClearCachedLevels();
                                 }
                                 ImGui.NextColumn();
@@ -387,7 +387,7 @@ namespace AutoDuty.Windows
                                     ImGuiEx.TextWrapped(new Vector4(0, 1, 0, 1), $"Leveling Mode: L{Player.Level} (i{ilvl})");
                                     foreach (var item in LevelingHelper.LevelingDuties.Select((Value, Index) => (Value, Index)))
                                     {
-                                        if (Plugin.Configuration.DutyModeEnum == DutyMode.Trust && !item.Value.TrustContent)
+                                        if (Plugin.Configuration.DutyModeEnum == DutyMode.Trust && !item.Value.DutyModes.HasFlag(DutyMode.Trust))
                                             continue;
                                         var disabled = !item.Value.CanRun() || (Plugin.Configuration.DutyModeEnum == DutyMode.Trust && !item.Value.CanTrustRun(true));
                                         if (!Plugin.Configuration.HideUnavailableDuties || !disabled)
@@ -408,21 +408,7 @@ namespace AutoDuty.Windows
                                     ImGuiEx.TextWrapped(new Vector4(0, 1, 1, 1), "Blue Mage cannot run Trust, Duty Support, Squadron or Variant dungeons. Please switch jobs or select a different category.");
                                 else if ((Player.Job.GetRole() != CombatRole.NonCombat && Player.Job != Job.BLU) || (Player.Job == Job.BLU && (Plugin.Configuration.DutyModeEnum == DutyMode.Regular || Plugin.Configuration.DutyModeEnum == DutyMode.Trial || Plugin.Configuration.DutyModeEnum == DutyMode.Raid)))
                                 {
-                                    Dictionary<uint, Content> dictionary = [];
-                                    if (Plugin.Configuration.DutyModeEnum == DutyMode.Support)
-                                        dictionary = ContentHelper.DictionaryContent.Where(x => x.Value.DawnContent).ToDictionary();
-                                    else if (Plugin.Configuration.DutyModeEnum == DutyMode.Trust)
-                                        dictionary = ContentHelper.DictionaryContent.Where(x => x.Value.TrustContent).ToDictionary();
-                                    else if (Plugin.Configuration.DutyModeEnum == DutyMode.Squadron)
-                                        dictionary = ContentHelper.DictionaryContent.Where(x => x.Value.GCArmyContent).ToDictionary();
-                                    else if (Plugin.Configuration.DutyModeEnum == DutyMode.Regular)
-                                        dictionary = ContentHelper.DictionaryContent.Where(x => x.Value.ContentType == 2).ToDictionary();
-                                    else if (Plugin.Configuration.DutyModeEnum == DutyMode.Trial)
-                                        dictionary = ContentHelper.DictionaryContent.Where(x => x.Value.ContentType == 4).ToDictionary();
-                                    else if (Plugin.Configuration.DutyModeEnum == DutyMode.Raid)
-                                        dictionary = ContentHelper.DictionaryContent.Where(x => x.Value.ContentType == 5).ToDictionary();
-                                    else if (Plugin.Configuration.DutyModeEnum == DutyMode.Variant)
-                                        dictionary = ContentHelper.DictionaryContent.Where(x => x.Value.VariantContent).ToDictionary();
+                                    Dictionary<uint, Content> dictionary = ContentHelper.DictionaryContent.Where(x => x.Value.DutyModes.HasFlag(Plugin.Configuration.DutyModeEnum)).ToDictionary();
 
                                     if (dictionary.Count > 0 && ObjectHelper.IsReady)
                                     {


### PR DESCRIPTION
Added DutyMode as First Argument to /ad run command
DutyMode's are the same as listed in the DropDown in MainTab
Added Error checking for every conceivable error to /ad Run Command