### PR TITLE
Download paths button in paths tab

### DIFF
--- a/AutoDuty/Windows/PathsTab.cs
+++ b/AutoDuty/Windows/PathsTab.cs
@@ -82,6 +82,11 @@ namespace AutoDuty.Windows
                     headers[key] = !anyHeaderOpen;
             }
 
+            if (ImGuiEx.ButtonWrapped("Download Paths"))
+            {
+                FileHelper.DownloadNewPaths();
+            }
+
 
             ImGuiStylePtr style = ImGui.GetStyle();
             ImGui.PushStyleColor(ImGuiCol.ChildBg, style.Colors[(int)ImGuiCol.FrameBg]);


### PR DESCRIPTION
A button that downloads the paths directly from github, and updates them right after.
In case dalamud fails at updating paths.