### PR TITLE
Update (933) Matoya's Relict.json

### DIFF
--- a/AutoDuty/Paths/(933) Matoya's Relict.json
+++ b/AutoDuty/Paths/(933) Matoya's Relict.json
@@ -477,9 +477,9 @@
         "Z": 0
       },
       "arguments": [
-        "Fiery Portal"
+        "2011292"
       ],
-      "note": ""
+      "note": "Fiery Portal"
     },
     {
       "tag": 0,


### PR DESCRIPTION
changed interactable "Fiery Portal" argument from name to ID