### PR TITLE
Update Wrath IPC to correct Enums

### DIFF
--- a/AutoDuty/IPC/IPCSubscriber.cs
+++ b/AutoDuty/IPC/IPCSubscriber.cs
@@ -271,28 +271,28 @@ namespace AutoDuty.IPC
         /// </summary>
         public enum AutoRotationConfigOption
         {
-            InCombatOnly, //bool
-            DPSRotationMode,
-            HealerRotationMode,
-            FATEPriority, //bool
-            QuestPriority,//bool
-            SingleTargetHPP,//int
-            AoETargetHPP,//int
-            SingleTargetRegenHPP,//int
-            ManageKardia,//bool
-            AutoRez,//bool
-            AutoRezDPSJobs,//bool
-            AutoCleanse,//bool
-            IncludeNPCs,//bool
+            InCombatOnly = 0, //bool
+            DPSRotationMode = 1,
+            HealerRotationMode = 2,
+            FATEPriority = 3, //bool
+            QuestPriority = 4,//bool
+            SingleTargetHPP = 5,//int
+            AoETargetHPP = 6,//int
+            SingleTargetRegenHPP = 7,//int
+            ManageKardia = 8,//bool
+            AutoRez = 9,//bool
+            AutoRezDPSJobs = 10,//bool
+            AutoCleanse = 11,//bool
+            IncludeNPCs = 12,//bool
         }
 
         public enum AutoRotationConfigDPSRotationSubset
         {
-            Manual,
-            Lowest_Current,
-            Highest_Max,
-            Tank_Target,
-            Nearest,
+            Manual = 0,
+            Lowest_Current = 4,
+            Highest_Max = 1,
+            Tank_Target = 5,
+            Nearest = 6,
         }
 
         /// <summary>
@@ -301,8 +301,8 @@ namespace AutoDuty.IPC
         /// </summary>
         public enum AutoRotationConfigHealerRotationSubset
         {
-            Manual,
-            Lowest_Current,
+            Manual = 0,
+            Lowest_Current = 2
         }
 
         private static Guid? _curLease;


### PR DESCRIPTION
Currently, passing the enums as is will change the wrong setting as enums are number values behind the scenes, and not strings. So for example, in current version of AD the `Lowest_Current` DPSRotationMode would be passed as `1` due to being the second item in the enumeration. However on the Wrath side, the value `1` corresponds to `Highest_Max`, so that's what it gets changed to (even if the UI shows otherwise, that's something I'm addressing that side).

Going forward it will be safer to push enums with their corresponding values on the Wrath side, which will normally be an index value (unless an item is removed however I am making similar changes to Wrath to put their values in to prevent breaks like this).

If this is merged and released before next Wrath update, the Wrath UI will show incorrectly but will function properly behind the scenes. 