### PR TITLE
Add Path: (1267) The Sunken Temple of Qarn

### DIFF
--- a/AutoDuty/Paths/(1267) The Sunken Temple of Qarn.json
+++ b/AutoDuty/Paths/(1267) The Sunken Temple of Qarn.json
@@ -1,0 +1,118 @@
+{
+  "actions": [
+    {
+      "tag": "None",
+      "name": "Boss",
+      "position": {
+        "X": -71.01,
+        "Y": -12,
+        "Z": -61.7
+      },
+      "arguments": [
+        "on"
+      ],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "MoveTo",
+      "position": {
+        "X": -25.371717,
+        "Y": -18.000046,
+        "Z": 0.06027671
+      },
+      "arguments": [],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "Boss",
+      "position": {
+        "X": 57.38,
+        "Y": -49.71,
+        "Z": -7.63
+      },
+      "arguments": [
+        ""
+      ],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "MoveTo",
+      "position": {
+        "X": 49.523148,
+        "Y": -19.000088,
+        "Z": 5.0506725
+      },
+      "arguments": [],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "MoveTo",
+      "position": {
+        "X": 120.22537,
+        "Y": -4.0001907,
+        "Z": -0.55485016
+      },
+      "arguments": [],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "MoveTo",
+      "position": {
+        "X": 189.58017,
+        "Y": -4.000005,
+        "Z": 0.053727567
+      },
+      "arguments": [],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "Interactable",
+      "position": {
+        "X": 189.58,
+        "Y": -4,
+        "Z": 0.05
+      },
+      "arguments": [
+        "2000658"
+      ],
+      "note": "The Scales of Judgment"
+    },
+    {
+      "tag": "None",
+      "name": "SelectYesno",
+      "position": {
+        "X": 189.58,
+        "Y": -4,
+        "Z": 0.05
+      },
+      "arguments": [
+        "Yes"
+      ],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "Boss",
+      "position": {
+        "X": 233.46,
+        "Y": -4,
+        "Z": -0.17
+      },
+      "arguments": [
+        ""
+      ],
+      "note": ""
+    }
+  ],
+  "meta": {
+    "createdAt": 203,
+    "changelog": [],
+    "notes": []
+  }
+}


### PR DESCRIPTION
Now that Sunken Temple of Qarn has been reworked for Duty Support, the problematic heads & pressure plates are no longer an issue, which makes this path SUPER simple. I added some pathing points right in front of each pressure plate though to ensure combat is encountered with the heads that must be killed.

Boss fights work flawlessly.

Simple path that I believe (no issues in my testing whatsoever) should be added to the AutoLevel list to bridge that gap after TamTara Deep Croft (Haukke is still an issue though, I'm working on ironing it out though).