### PR TITLE
Add configurable desynth skill-up limit

### DIFF
--- a/AutoDuty/Helpers/DesynthHelper.cs
+++ b/AutoDuty/Helpers/DesynthHelper.cs
@@ -95,7 +95,7 @@ namespace AutoDuty.Helpers
 
                         if (itemLevel == null || itemSheetRow == null) continue;
 
-                        if (!Plugin.Configuration.AutoDesynthSkillUp || (desynthLevel < itemLevel + 50 && desynthLevel < _maxDesynthLevel))
+                        if (!Plugin.Configuration.AutoDesynthSkillUp || (desynthLevel < itemLevel + Plugin.Configuration.AutoDesynthSkillUpLimit && desynthLevel < _maxDesynthLevel))
                         {
                             DebugLog($"Salvaging Item({i}): {itemSheetRow.Value.Name.ToString()} with iLvl {itemLevel} because our desynth level is {desynthLevel}");
                             foundOne = true;

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -252,6 +252,7 @@ public class Configuration : IPluginConfiguration
                 AutoDesynth = false;
         }
     }
+    public int AutoDesynthSkillUpLimit = 50;
     internal bool autoGCTurnin = false;
     public bool AutoGCTurnin
     {
@@ -1470,6 +1471,18 @@ public static class ConfigTab
                             {
                                 Configuration.AutoDesynthSkillUp = Configuration.autoDesynthSkillUp;
                                 Configuration.Save();
+                            }
+                            if (Configuration.AutoDesynthSkillUp)
+                            {
+                                ImGui.Text("Item Level Limit");
+                                ImGuiComponents.HelpMarker("Stops desynthesising an item once your desynthesis skill reaches the Item Level + this limit.");
+                                ImGui.SameLine();
+                                ImGui.PushItemWidth(ImGui.GetContentRegionAvail().X);
+                                if (ImGui.SliderInt("##AutoDesynthSkillUpLimit", ref Configuration.AutoDesynthSkillUpLimit, 0, 50))
+                                {
+                                    Configuration.AutoDesynthSkillUpLimit = Math.Clamp(Configuration.AutoDesynthSkillUpLimit, 0, 50);
+                                    Configuration.Save();
+                                }
                             }
                             ImGui.Unindent();
                         }


### PR DESCRIPTION
As your desynthesis skill gets closer to the current item level cap (iLevel + 50), each desynthesis grants progressively less experience. This can lead to inefficient use of items once you’re close to the cap. By letting users set a maximum skill‐up limit, we avoid inefficient desynthesis XP gains and make better use of item drops when levelling desynthesis.

**Changes:**
- Introduced a new "Item Level Limit" setting under "Only Skill Ups" in AutoDuty’s config UI.
- When your desynthesis skill >= (iLevel + Limit), AutoDuty will skip further desynthesis of that item.
- Default limit is 50 (matches current behaviour), users can decrease down to 0.
