### PR TITLE
added StopForCombat to Ala Mhigo to fix stuck at turrets + notes changes to Antitower

### DIFF
--- a/AutoDuty/Paths/(1111) The Antitower.json
+++ b/AutoDuty/Paths/(1111) The Antitower.json
@@ -310,7 +310,7 @@
       "arguments": [
         ""
       ],
-      "note": ""
+      "note": "Small Calca and Brina dolls"
     },
     {
       "tag": "None",
@@ -323,7 +323,7 @@
       "arguments": [
         ""
       ],
-      "note": "Small Calca and Brina dolls"
+      "note": "Wait for phase change and fight big Calcabrina doll"
     },
     {
       "tag": "None",
@@ -336,7 +336,7 @@
       "arguments": [
         ""
       ],
-      "note": "Wait for phase change and fight big Calcabrina doll"
+      "note": ""
     }
   ],
   "meta": {

--- a/AutoDuty/Paths/(1146) Ala Mhigo.json
+++ b/AutoDuty/Paths/(1146) Ala Mhigo.json
@@ -158,27 +158,40 @@
     },
     {
       "tag": "None",
-      "name": "MoveTo",
+      "name": "StopForCombat",
       "position": {
         "X": 250,
         "Y": 106.45,
         "Z": -85.17
       },
       "arguments": [
-        ""
+        "false"
       ],
       "note": ""
     },
     {
       "tag": "None",
-      "name": "MoveTo",
+      "name": "StopForCombat",
       "position": {
         "X": 234.48,
         "Y": 110,
         "Z": -149.57
       },
       "arguments": [
-        ""
+        "true"
+      ],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "StopForCombat",
+      "position": {
+        "X": 229.04869,
+        "Y": 110,
+        "Z": -150.04295
+      },
+      "arguments": [
+        "false"
       ],
       "note": ""
     },
@@ -192,6 +205,19 @@
       },
       "arguments": [
         ""
+      ],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "StopForCombat",
+      "position": {
+        "X": 216.24066,
+        "Y": 119.84013,
+        "Z": -247.28032
+      },
+      "arguments": [
+        "true"
       ],
       "note": ""
     },
@@ -279,6 +305,10 @@
       {
         "version": 189,
         "change": "Adjusted tags to string values"
+      },
+      {
+        "version": 213,
+        "change": ""
       }
     ],
     "notes": []


### PR DESCRIPTION
AntiTower:
- Moved the notes to the correct step

Ala Mhigo:
- Changed some steps to StopForCombat. There are a couple turret mobs located right around a corner. The bot often gets stuck on the corner waiting for the combat to come to it... except the mobs are unmoving turrets. BossMod/Reborn followtarget also causes bot to get stuck, because it will just run in a straight line into the corner.