### PR TITLE
Config profile bugs

### DIFF
--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -157,9 +157,9 @@ public class ConfigurationMain : IEzConfig
     {
         Svc.Framework.RunOnTick(() =>
         {
-            DebugLog("Setting to default profile");
+            DebugLog($"Setting to default profile for {Player.Name} ({Player.CID}) {PlayerHelper.IsValid}");
 
-            if (PlayerHelper.IsValid && this.profileByCID.TryGetValue(Player.CID, out string? charProfile))
+            if (Player.Available && this.profileByCID.TryGetValue(Player.CID, out string? charProfile))
                 if (this.SetProfile(charProfile))
                     return;
             DebugLog("No char default found. Using general default");

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -217,6 +217,7 @@ public class ConfigurationMain : IEzConfig
     {
         this.profileData.Remove(this.GetCurrentProfile);
         this.profileByName.Remove(this.ActiveProfileName);
+        this.SetProfile(CONFIGNAME_BARE);
         this.SetProfileToDefault();
     }
 

--- a/AutoDuty/Windows/Config.cs
+++ b/AutoDuty/Windows/Config.cs
@@ -678,12 +678,20 @@ public static class ConfigTab
                 if (configCombo)
                     foreach (string key in ConfigurationMain.Instance.ConfigNames)
                     {
+                        var icon = false;
                         if (key == ConfigurationMain.CONFIGNAME_BARE)
+                        {
                             ImGuiHelper.DrawIcon(FontAwesomeIcon.Lock);
+                            icon = true;
+                        }
                         if (key == ConfigurationMain.Instance.DefaultConfigName)
+                        {
                             ImGuiHelper.DrawIcon(FontAwesomeIcon.CheckCircle);
+                            icon = true;
+                        }
                         float x = ImGui.GetCursorPosX();
-                        ImGui.SameLine(0.1f);
+                        if (icon)
+                            ImGui.SameLine(0.1f);
                         ImGui.SetItemAllowOverlap();
                         if (ImGui.Selectable($"###{key}ConfigSelectable"))
                             ConfigurationMain.Instance.SetProfile(key);


### PR DESCRIPTION
Fixes 3 bugs found testing the config profiles


1) profiles with no icon all stack on eachother
![image](https://github.com/user-attachments/assets/a15d145e-eaa2-4a3c-be12-8bb6965fb7aa)


2) Game crashes if you delete a config.

3) Swapping characters doesnt load the per char config assignment because the config loads before the char is fully ready. but CID is still available.