### PR TITLE
Set player target to be boss npc in Boss action

### DIFF
--- a/AutoDuty/Managers/ActionsManager.cs
+++ b/AutoDuty/Managers/ActionsManager.cs
@@ -571,6 +571,7 @@ namespace AutoDuty.Managers
             if (Plugin.BossObject == null)
                 _taskManager.Enqueue(() => (Plugin.BossObject = GetBossObject()) != null, "Boss-GetBossObject");
             _taskManager.Enqueue(() => Plugin.Action = $"Boss: {Plugin.BossObject?.Name.TextValue ?? ""}", "Boss-SetActionVar");
+            _taskManager.Enqueue(() => Svc.Targets.Target = Plugin.BossObject, "Boss-SetTarget");
             _taskManager.Enqueue(() => Svc.Condition[ConditionFlag.InCombat], "Boss-WaitInCombat");
             _taskManager.Enqueue(() => BossCheck(), int.MaxValue, "Boss-BossCheck");
             _taskManager.Enqueue(() => { Plugin.BossObject = null; }, "Boss-ClearBossObject");


### PR DESCRIPTION
setting player target to be the boss npc on a boss action makes it so that bosses who do not "aggro" onto the player by distance are handled. (eg: A9S)