### PR TITLE
Make content has path IPC check for path not for content

### DIFF
--- a/AutoDuty/IPC/IPCProvider.cs
+++ b/AutoDuty/IPC/IPCProvider.cs
@@ -21,7 +21,7 @@ namespace AutoDuty.IPC
         [EzIPC] public bool IsNavigating() => Plugin.States.HasFlag(PluginState.Navigating);
         [EzIPC] public bool IsLooping() => Plugin.States.HasFlag(PluginState.Looping);
         [EzIPC] public bool IsStopped() => Plugin.Stage == Stage.Stopped;
-        [EzIPC] public bool ContentHasPath(uint territoryType) => ContentHelper.DictionaryContent.ContainsKey(territoryType);
+        [EzIPC] public bool ContentHasPath(uint territoryType) => ContentPathsManager.DictionaryPaths.ContainsKey(territoryType);
 
         //Callback for Wrath Combo Lease Cancel
         [EzIPC] public void WrathComboCallback(int reason, string s) => Wrath_IPCSubscriber.CancelActions(reason, s);


### PR DESCRIPTION
Change the dictionary the IPC is checking from the content helper dictionary to the path manager dictionary.

The content helper dict seems to contain all content regardless if it has a path or not.