### PR TITLE
Fixed issues in Hullbreaker Isle, Copperbell Mines (Hard), and Binding Coils T4

### DIFF
--- a/AutoDuty/Paths/(244) The Binding Coil of Bahamut - Turn 4.json
+++ b/AutoDuty/Paths/(244) The Binding Coil of Bahamut - Turn 4.json
@@ -17,14 +17,14 @@
       "tag": "None",
       "name": "Interactable",
       "position": {
-        "X": 0,
-        "Y": 0,
-        "Z": 0
+        "X": -15.032367,
+        "Y": 0.05813718,
+        "Z": 16.869753
       },
       "arguments": [
-        "Silent Terminal"
+        "2000633"
       ],
-      "note": ""
+      "note": "Silent Terminal"
     },
     {
       "tag": "None",
@@ -97,6 +97,10 @@
       {
         "version": 189,
         "change": "Adjusted tags to string values"
+      },
+      {
+        "version": 221,
+        "change": ""
       }
     ],
     "notes": []

--- a/AutoDuty/Paths/(349) Copperbell Mines (Hard).json
+++ b/AutoDuty/Paths/(349) Copperbell Mines (Hard).json
@@ -50,9 +50,9 @@
       "tag": "None",
       "name": "Wait",
       "position": {
-        "X": -184.04,
-        "Y": -5.87,
-        "Z": -207.46
+        "X": -183.95573,
+        "Y": 23.999985,
+        "Z": -207.47868
       },
       "arguments": [
         "10000"
@@ -592,6 +592,10 @@
       {
         "version": 189,
         "change": "Adjusted tags to string values"
+      },
+      {
+        "version": 224,
+        "change": ""
       }
     ],
     "notes": []

--- a/AutoDuty/Paths/(361) Hullbreaker Isle.json
+++ b/AutoDuty/Paths/(361) Hullbreaker Isle.json
@@ -307,19 +307,6 @@
     },
     {
       "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 228.36,
-        "Y": 62.58,
-        "Z": -141.09
-      },
-      "arguments": [
-        "2004054"
-      ],
-      "note": "Stone Tablet"
-    },
-    {
-      "tag": "None",
       "name": "MoveTo",
       "position": {
         "X": 206.47899,
@@ -420,12 +407,73 @@
       "note": ""
     },
     {
+      "tag": "Treasure",
+      "name": "TreasureCoffer",
+      "position": {
+        "X": 67.5368,
+        "Y": 53.609344,
+        "Z": -211.85718
+      },
+      "arguments": [],
+      "note": ""
+    },
+    {
       "tag": "None",
       "name": "Interactable",
       "position": {
-        "X": 82.26,
-        "Y": 53.83,
-        "Z": -225.51
+        "X": 70.75531,
+        "Y": 53.234386,
+        "Z": -213.07759
+      },
+      "arguments": [
+        "2004079"
+      ],
+      "note": "Treasure Coffer"
+    },
+    {
+      "tag": "None",
+      "name": "Interactable",
+      "position": {
+        "X": 73.384796,
+        "Y": 53.102295,
+        "Z": -209.61041
+      },
+      "arguments": [
+        "2004055"
+      ],
+      "note": "Stone Tablet"
+    },
+    {
+      "tag": "Treasure",
+      "name": "TreasureCoffer",
+      "position": {
+        "X": 39.08534,
+        "Y": 44.220364,
+        "Z": -129.38905
+      },
+      "arguments": [],
+      "note": ""
+    },
+    {
+      "tag": "None",
+      "name": "Interactable",
+      "position": {
+        "X": 38.479786,
+        "Y": 44.663124,
+        "Z": -132.91002
+      },
+      "arguments": [
+        "2004078"
+      ],
+      "note": "Treasure Coffer"
+    },
+    {
+      "tag": "None",
+      "name": "Interactable",
+      "position": {
+        "X": 22.83309,
+        "Y": 44.670025,
+        "Z": -133.07677
       },
       "arguments": [
         "2004076"
@@ -436,165 +484,14 @@
       "tag": "None",
       "name": "Interactable",
       "position": {
-        "X": 82.26,
-        "Y": 53.83,
-        "Z": -225.51
-      },
-      "arguments": [
-        "2004055"
-      ],
-      "note": "Stone Tablet"
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 66.871216,
-        "Y": 53.574364,
-        "Z": -213.49583
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 66.88,
-        "Y": 53.56,
-        "Z": -213.78
-      },
-      "arguments": [
-        "2004077"
-      ],
-      "note": "Treasure Coffer"
-    },
-    {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 66.63,
-        "Y": 53.61,
-        "Z": -213.3
+        "X": 23.961056,
+        "Y": 44.678116,
+        "Z": -136.11554
       },
       "arguments": [
         "2004056"
       ],
       "note": "Stone Tablet"
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 67.583664,
-        "Y": 53.761677,
-        "Z": -210.13669
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 68.26,
-        "Y": 53.62,
-        "Z": -210.69
-      },
-      "arguments": [
-        "2004078"
-      ],
-      "note": "Treasure Coffer"
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 90.41098,
-        "Y": 50.193024,
-        "Z": -198.46199
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 56.189617,
-        "Y": 44.590378,
-        "Z": -170.17323
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 37.418686,
-        "Y": 42.917793,
-        "Z": -169.39072
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 30.260262,
-        "Y": 44.087963,
-        "Z": -147.78922
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 18.792936,
-        "Y": 44.894405,
-        "Z": -136.52281
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 40.096798,
-        "Y": 44.367115,
-        "Z": -130.46419
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "MoveTo",
-      "position": {
-        "X": 39.75074,
-        "Y": 44.185642,
-        "Z": -127.393326
-      },
-      "arguments": [],
-      "note": ""
-    },
-    {
-      "tag": "None",
-      "name": "Interactable",
-      "position": {
-        "X": 39.75,
-        "Y": 44.19,
-        "Z": -127.39
-      },
-      "arguments": [
-        "2004079"
-      ],
-      "note": "Treasure Coffer"
     },
     {
       "tag": "None",
@@ -912,6 +809,10 @@
       {
         "version": 189,
         "change": "Adjusted tags to string values"
+      },
+      {
+        "version": 224,
+        "change": ""
       }
     ],
     "notes": []


### PR DESCRIPTION
Hullbreaker Isla path broke in the part where you have to kill some mimics and pick up the stone tablets they drop, AD wouldn't pick up the second set of tablets and would get stuck there. Poking around with it I found out that the path seemingly had the wrong tablet IDs, so I redid the whole part (and deleted a bunch of redundant/unnecessary steps).

In Copperbell MInes Hard, AD would get stuck right at the start because it would activate the lift, then run out of it before the door closed; I finally noticed the issue was that the Wait command after the lever had the wrong coordinates.

Binding Coils T4 got stuck right at the start with the Silent Terminal missing ID, redid that step.